### PR TITLE
renaming fields to be more specific, and reorder them 

### DIFF
--- a/data-module/SignedDevonTicket.asd
+++ b/data-module/SignedDevonTicket.asd
@@ -17,9 +17,9 @@
     <namedType name="Ticket">
         <type>
             <sequence>
+                <element name="devconId" type="asnx:INTEGER"/>
                 <element name="ticketId" type="asnx:INTEGER"/>
                 <element name="ticketClass" type="asnx:INTEGER"/>
-                <element name="conferenceId" type="asnx:INTEGER"/>
                 <element name="riddle" type="asnx:OCTET-STRING">
                     <annotation>The elliptic curve point that is the riddle</annotation>
                 </element>

--- a/data-module/SignedDevonTicket.asn
+++ b/data-module/SignedDevonTicket.asn
@@ -14,9 +14,9 @@ SignedTicket ::= SEQUENCE {
 
 
 Ticket ::= SEQUENCE {
+    devonId     INTEGER,
     ticketId         INTEGER,
     ticketClass      INTEGER,
-    conferenceId     INTEGER,
 --  (currently not specified)      --
 --  co2_token         OCTET STRING --
     riddle         OCTET STRING

--- a/src/main/java/com/alphawallet/attestation/ticket/Ticket.java
+++ b/src/main/java/com/alphawallet/attestation/ticket/Ticket.java
@@ -109,9 +109,9 @@ public class Ticket implements Attestable {
 
   private ASN1Sequence makeTicket() {
     ASN1EncodableVector ticket = new ASN1EncodableVector();
+    ticket.add(new ASN1Integer(devconId));
     ticket.add(new ASN1Integer(ticketId));
     ticket.add(new ASN1Integer(ticketClass.getValue()));
-    ticket.add(new ASN1Integer(devconId));
     ticket.add(new DEROctetString(riddle));
     return new DERSequence(ticket);
   }

--- a/src/main/java/com/alphawallet/attestation/ticket/Ticket.java
+++ b/src/main/java/com/alphawallet/attestation/ticket/Ticket.java
@@ -38,7 +38,7 @@ public class Ticket implements Attestable {
 
   private final BigInteger ticketId;
   private TicketClass ticketClass = null;
-  private final int conferenceId;
+  private final int devconId;
   private final byte[] riddle;
   private final AlgorithmIdentifier algorithm;
   private final byte[] signature;
@@ -51,16 +51,16 @@ public class Ticket implements Attestable {
    * @param mail The mail address of the recipient
    * @param ticketId The Id of the ticket
    * @param ticketClass The type of this ticket
-   * @param conferenceId The id of the conference for which the ticket should be used
+   * @param devconId The id of the conference for which the ticket should be used
    * @param keys The keys used to sign the cheque
    * @param secret the secret that must be known to cash the cheque
    */
-  public Ticket(String mail, BigInteger ticketId, TicketClass ticketClass, int conferenceId,
+  public Ticket(String mail, int devconId, BigInteger ticketId, TicketClass ticketClass,
       AsymmetricCipherKeyPair keys, BigInteger secret ) {
     AttestationCrypto crypto = new AttestationCrypto(new SecureRandom());
     this.ticketId = ticketId;
     this.ticketClass = ticketClass;
-    this.conferenceId = conferenceId;
+    this.devconId = devconId;
     this.riddle = crypto.makeRiddle(mail, AttestationType.EMAIL, secret);
     try {
       SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(
@@ -82,10 +82,10 @@ public class Ticket implements Attestable {
     }
   }
 
-  public Ticket(BigInteger ticketId, TicketClass ticketClass, int conferenceId, byte[] riddle, byte[] signature, AsymmetricKeyParameter publicKey) {
+  public Ticket(int devconId, BigInteger ticketId, TicketClass ticketClass, byte[] riddle, byte[] signature, AsymmetricKeyParameter publicKey) {
     this.ticketId = ticketId;
     this.ticketClass = ticketClass;
-    this.conferenceId = conferenceId;
+    this.devconId = devconId;
     this.riddle = riddle;
     try {
       SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(
@@ -111,7 +111,7 @@ public class Ticket implements Attestable {
     ASN1EncodableVector ticket = new ASN1EncodableVector();
     ticket.add(new ASN1Integer(ticketId));
     ticket.add(new ASN1Integer(ticketClass.getValue()));
-    ticket.add(new ASN1Integer(conferenceId));
+    ticket.add(new ASN1Integer(devconId));
     ticket.add(new DEROctetString(riddle));
     return new DERSequence(ticket);
   }
@@ -154,8 +154,8 @@ public class Ticket implements Attestable {
     return ticketClass;
   }
 
-  public int getConferenceId() {
-    return conferenceId;
+  public int getDevconId() {
+    return devconId;
   }
 
   public byte[] getRiddle() {

--- a/src/main/java/com/alphawallet/attestation/ticket/TicketDecoder.java
+++ b/src/main/java/com/alphawallet/attestation/ticket/TicketDecoder.java
@@ -38,7 +38,7 @@ public class TicketDecoder implements AttestableObjectDecoder<Ticket> {
     if (ticketClass == null) {
       throw new IOException("Not valid ticket class");
     }
-    int conferenceId = (ASN1Integer.getInstance(ticket.getObjectAt(2))).getValue().intValueExact();
+    int devconId = (ASN1Integer.getInstance(ticket.getObjectAt(2))).getValue().intValueExact();
     byte[] riddle = (ASN1OctetString.getInstance(ticket.getObjectAt(3))).getOctets();
 
     AlgorithmIdentifier algorithm = AlgorithmIdentifier.getInstance(asn1.getObjectAt(1));
@@ -50,6 +50,6 @@ public class TicketDecoder implements AttestableObjectDecoder<Ticket> {
 
     // Verify signature
     byte[] signature = DERBitString.getInstance(asn1.getObjectAt(2)).getBytes();
-    return new Ticket(ticketId, ticketClass, conferenceId, riddle, signature, publicKey);
+    return new Ticket(devconId, ticketId, ticketClass, riddle, signature, publicKey);
   }
 }

--- a/src/main/java/com/alphawallet/attestation/ticket/TicketDecoder.java
+++ b/src/main/java/com/alphawallet/attestation/ticket/TicketDecoder.java
@@ -27,8 +27,9 @@ public class TicketDecoder implements AttestableObjectDecoder<Ticket> {
     ASN1InputStream input = new ASN1InputStream(encoding);
     ASN1Sequence asn1 = ASN1Sequence.getInstance(input.readObject());
     ASN1Sequence ticket = ASN1Sequence.getInstance(asn1.getObjectAt(0));
-    BigInteger ticketId = (ASN1Integer.getInstance(ticket.getObjectAt(0))).getValue();
-    int ticketClassInt = ASN1Integer.getInstance(ticket.getObjectAt(1)).getValue().intValueExact();
+    int devconId = (ASN1Integer.getInstance(ticket.getObjectAt(0))).getValue().intValueExact();
+    BigInteger ticketId = (ASN1Integer.getInstance(ticket.getObjectAt(1))).getValue();
+    int ticketClassInt = ASN1Integer.getInstance(ticket.getObjectAt(2)).getValue().intValueExact();
     TicketClass ticketClass = null;
     for (TicketClass current : TicketClass.values()) {
       if (current.getValue() == ticketClassInt) {
@@ -38,7 +39,6 @@ public class TicketDecoder implements AttestableObjectDecoder<Ticket> {
     if (ticketClass == null) {
       throw new IOException("Not valid ticket class");
     }
-    int devconId = (ASN1Integer.getInstance(ticket.getObjectAt(2))).getValue().intValueExact();
     byte[] riddle = (ASN1OctetString.getInstance(ticket.getObjectAt(3))).getOctets();
 
     AlgorithmIdentifier algorithm = AlgorithmIdentifier.getInstance(asn1.getObjectAt(1));

--- a/src/test/java/com/alphawallet/attestation/TestURL.java
+++ b/src/test/java/com/alphawallet/attestation/TestURL.java
@@ -71,7 +71,7 @@ public class TestURL {
     BigInteger ticketID = new BigInteger("417541561854");
     TicketClass ticketClass = TicketClass.REGULAR;
     BigInteger senderSecret = new BigInteger("45845870684");
-    Ticket ticket = new Ticket("mah@mah.com", ticketID, ticketClass, 6, senderKeys, senderSecret);
+    Ticket ticket = new Ticket("mah@mah.com", 6, ticketID, ticketClass, senderKeys, senderSecret);
 
     byte[] senderPublicKey = SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(senderKeys.getPublic()).getPublicKeyData().getEncoded();
     String url = URLUtility.encodeList(Arrays.asList(ticket.getDerEncoding(), senderPublicKey));
@@ -83,7 +83,7 @@ public class TestURL {
     assertArrayEquals(ticket.getDerEncoding(), newTicket.getDerEncoding());
 
     AsymmetricKeyParameter newIssuerPublicKey = SignatureUtility.restoreKey(decoded.get(1));
-    Ticket otherConstructorTicket = new Ticket(newTicket.getTicketId(), newTicket.getTicketClass(), newTicket.getConferenceId(),
+    Ticket otherConstructorTicket = new Ticket(newTicket.getDevconId(), newTicket.getTicketId(), newTicket.getTicketClass(),
         newTicket.getRiddle(), newTicket.getSignature(), newIssuerPublicKey);
     assertArrayEquals(ticket.getDerEncoding(), otherConstructorTicket.getDerEncoding());
   }
@@ -93,7 +93,7 @@ public class TestURL {
     BigInteger ticketID = new BigInteger("14840860468475837258758376");
     TicketClass ticketClass = TicketClass.VIP;
     BigInteger senderSecret = new BigInteger("186416");
-    Ticket ticket = new Ticket("ticket@test.ts", ticketID, ticketClass, 6, senderKeys, senderSecret);
+    Ticket ticket = new Ticket("ticket@test.ts", 6, ticketID, ticketClass, senderKeys, senderSecret);
     String url = URLUtility.encodeData(ticket.getDerEncoding());
     Ticket newTicket =  (new TicketDecoder(senderKeys.getPublic())).decode(URLUtility.decodeData(url));
     String newUrl = URLUtility.encodeData(newTicket.getDerEncoding());

--- a/src/test/java/com/alphawallet/attestation/ticket/TestTicket.java
+++ b/src/test/java/com/alphawallet/attestation/ticket/TestTicket.java
@@ -39,17 +39,17 @@ public class TestTicket {
 
   @Test
   public void testFullDecoding() throws Exception {
-    Ticket ticket = new Ticket(MAIL, TICKET_ID, TICKET_CLASS, CONFERENCE_ID, senderKeys, SECRET);
+    Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, senderKeys, SECRET);
     byte[] encoded = ticket.getDerEncoding();
     Ticket newTicket = (new TicketDecoder(senderKeys.getPublic())).decode(encoded);
     assertTrue(ticket.verify());
     assertArrayEquals(encoded, newTicket.getDerEncoding());
 
-    Ticket otherConstructor = new Ticket(newTicket.getTicketId(), newTicket.getTicketClass(), newTicket.getConferenceId(),
+    Ticket otherConstructor = new Ticket(newTicket.getDevconId(), newTicket.getTicketId(), newTicket.getTicketClass(),
         newTicket.getRiddle(), newTicket.getSignature(), newTicket.getPublicKey());
     assertEquals(ticket.getTicketId(), otherConstructor.getTicketId());
     assertEquals(ticket.getTicketClass(), otherConstructor.getTicketClass());
-    assertEquals(ticket.getConferenceId(), otherConstructor.getConferenceId());
+    assertEquals(ticket.getDevconId(), otherConstructor.getDevconId());
     assertEquals(ticket.getAlgorithm(), otherConstructor.getAlgorithm());
     assertArrayEquals(ticket.getRiddle(), otherConstructor.getRiddle());
     assertArrayEquals(ticket.getSignature(), otherConstructor.getSignature());
@@ -63,7 +63,7 @@ public class TestTicket {
 
   @Test
   public void testIllegalKeys() throws Exception {
-    Ticket ticket = new Ticket(MAIL, TICKET_ID, TICKET_CLASS, CONFERENCE_ID, senderKeys, SECRET);
+    Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, senderKeys, SECRET);
     Field field = ticket.getClass().getDeclaredField("signature");
     field.setAccessible(true);
     // Change a bit in the signature
@@ -71,8 +71,8 @@ public class TestTicket {
     assertFalse(ticket.verify());
     // Check we cannot make a new ticket with invalid signature
     try {
-      Ticket newTicket = new Ticket(ticket.getTicketId(), ticket.getTicketClass(),
-          ticket.getConferenceId(), ticket.getRiddle(), ticket.getSignature(),
+      Ticket newTicket = new Ticket(ticket.getDevconId(), ticket.getTicketId(), ticket.getTicketClass(),
+          ticket.getRiddle(), ticket.getSignature(),
           senderKeys.getPublic());
       fail();
     } catch (IllegalArgumentException e) {
@@ -82,7 +82,7 @@ public class TestTicket {
 
   @Test
   public void testWrongKey() throws Exception {
-    Ticket ticket = new Ticket(MAIL, TICKET_ID, TICKET_CLASS, CONFERENCE_ID, senderKeys, SECRET);
+    Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, senderKeys, SECRET);
     byte[] encoding = ticket.getDerEncoding();
     try {
       Ticket otherTicket = (new TicketDecoder(otherKeys.getPublic())).decode(encoding);

--- a/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
+++ b/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
@@ -60,7 +60,7 @@ public class TestUseTicket {
   public void makeAttestedTicket() {
     Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL );
     SignedAttestation signed = new SignedAttestation(att, attestorKeys);
-    Ticket ticket = new Ticket(MAIL, TICKET_ID, TICKET_CLASS, CONFERENCE_ID, ticketIssuerKeys, TICKET_SECRET);
+    Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketIssuerKeys, TICKET_SECRET);
     attestedTicket = new AttestedObject<Ticket>(ticket, signed, subjectKeys, ATTESTATION_SECRET, TICKET_SECRET);
     assertTrue(attestedTicket.verify());
     assertTrue(attestedTicket.checkValidity());
@@ -185,7 +185,7 @@ public class TestUseTicket {
 
   @Test
   public void testNegativeWrongRiddle() throws Exception {
-    Ticket newTicket  = new Ticket(MAIL, TICKET_ID, TICKET_CLASS, CONFERENCE_ID, subjectKeys, TICKET_SECRET);
+    Ticket newTicket  = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
     assertTrue(newTicket.checkValidity());
     assertTrue(newTicket.verify());
     Field field = attestedTicket.getClass().getDeclaredField("attestableObject");
@@ -203,7 +203,7 @@ public class TestUseTicket {
     Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedAttestation signed = new SignedAttestation(att, attestorKeys);
     // Add an extra t in the mail
-    Ticket ticket = new Ticket("testt@test.ts", TICKET_ID, TICKET_CLASS, CONFERENCE_ID, subjectKeys, TICKET_SECRET);
+    Ticket ticket = new Ticket("testt@test.ts", CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
     try {
       AttestedObject current = new AttestedObject(ticket, signed, subjectKeys, ATTESTATION_SECRET,
           TICKET_SECRET);
@@ -217,7 +217,7 @@ public class TestUseTicket {
   public void testNegativeConstruction2() {
     Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedAttestation signed = new SignedAttestation(att, attestorKeys);
-    Ticket ticket = new Ticket(MAIL, TICKET_ID, TICKET_CLASS, CONFERENCE_ID, subjectKeys, TICKET_SECRET);
+    Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
     try {
       // Wrong subject secret
       AttestedObject current = new AttestedObject(ticket, signed, subjectKeys,


### PR DESCRIPTION
I got someone confused and asked me why `conferenceId` when there is only one conference in Devcon (unlike some forum events which is made up of smaller conferences). The ordering and naming removes the confusion