### PR TITLE
Add integration tests (all test classes renamed!!!)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,11 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    intTestImplementation.extendsFrom implementation
+    intTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
 dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.13.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.13.0'
@@ -28,7 +33,9 @@ dependencies {
     implementation('com.amazonaws:aws-lambda-java-events:2.2.6')
     implementation 'org.json:json:20200518'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    intTestImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    intTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     implementation 'org.web3j:core:4.6.0'
     implementation group: 'com.github.cliftonlabs', name: 'json-simple', version: '3.1.0'
     implementation group: 'commons-cli', name: 'commons-cli', version: '1.4'
@@ -50,10 +57,22 @@ sourceSets {
             exclude 'dk/alexandra/stormbird/cheque' // the code depends on objsys library
         }
     }
+    intTest {
+        java {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+	}
+    }
 }
 
 test {
     useJUnitPlatform()
+}
+
+task integrationTest(type: Test) {
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.intTest.output.classesDirs
+    classpath = sourceSets.intTest.runtimeClasspath
 }
 
 shadowJar {

--- a/src/intTest/java/com/alphawallet/attestation/ProofOfKnolwedgeIntegTest.java
+++ b/src/intTest/java/com/alphawallet/attestation/ProofOfKnolwedgeIntegTest.java
@@ -1,0 +1,51 @@
+package com.alphawallet.attestation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alphawallet.attestation.core.AttestationCrypto;
+import com.alphawallet.attestation.demo.SmartContract;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ProofOfKnolwedgeIntegTest {
+    private static AttestationCrypto crypto;
+    private static SecureRandom rand;
+
+    @BeforeAll
+    public static void setupKeys() throws Exception {
+        rand = SecureRandom.getInstance("SHA1PRNG");
+        rand.setSeed("seed".getBytes());
+        crypto = new AttestationCrypto(rand);
+    }
+
+    @Test
+    public void TestContract() {
+        SmartContract sc = new SmartContract();
+        // TODO @James B this is where we need to use verifyEqualityProof and computeEqualityProof
+        for (int i = 0; i < 30; i++) {
+            byte[] bytes = new byte[32];
+            rand.nextBytes(bytes);
+            BigInteger rVal = new BigInteger(bytes);
+            ProofOfExponent pok = crypto.computeAttestationProof(rVal);
+            assertTrue(crypto.verifyAttestationRequestProof(pok));
+            assertTrue(sc.testEncoding(pok));
+        }
+
+        //now check fail
+        for (int i = 0; i < 5; i++) {
+            byte[] bytes = new byte[32];
+            rand.nextBytes(bytes);
+            BigInteger rVal = new BigInteger(bytes);
+            ProofOfExponent pok = crypto.computeAttestationProof(rVal);
+            assertTrue(crypto.verifyAttestationRequestProof(pok));
+            ProofOfExponent newPok = new ProofOfExponent(pok.getBase(), pok.getRiddle(), pok.getPoint(), pok.getChallenge().add(BigInteger.ONE));
+            assertFalse(sc.testEncoding(newPok));
+        }
+    }
+
+}

--- a/src/test/java/com/alphawallet/attestation/AttestationRequestTest.java
+++ b/src/test/java/com/alphawallet/attestation/AttestationRequestTest.java
@@ -14,7 +14,7 @@ import org.bouncycastle.crypto.params.ECKeyParameters;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class TestAttestationRequest {
+public class AttestationRequestTest {
   private static AsymmetricCipherKeyPair subjectKeys;
   private static AttestationCrypto crypto;
 

--- a/src/test/java/com/alphawallet/attestation/AttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/AttestationTest.java
@@ -19,7 +19,7 @@ import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class TestAttestation {
+public class AttestationTest {
 
     private static AsymmetricCipherKeyPair subjectKeys;
     private static SecureRandom rand;
@@ -64,7 +64,7 @@ public class TestAttestation {
 
     @Test
     public void testMakeUnsignedX509Attestation() throws IOException {
-        byte[] res = TestHelper.makeUnsignedx509Att(subjectKeys.getPublic()).getPrehash();
+        byte[] res = HelperTest.makeUnsignedx509Att(subjectKeys.getPublic()).getPrehash();
         assertTrue(res != null);
         Path p = Files.createTempFile("unsigned_x509", ".der");
         System.out.println("To check the unsigned X509 attestation, run this:");
@@ -74,21 +74,21 @@ public class TestAttestation {
 
     @Test
     public void testInvalid() {
-        Attestation res = TestHelper.makeMinimalAtt();
+        Attestation res = HelperTest.makeMinimalAtt();
         res.setDataObject(null);
         assertFalse(res.checkValidity());
     }
 
     @Test
     public void testInvalidx509() throws IOException {
-        Attestation res = TestHelper.makeUnsignedx509Att(subjectKeys.getPublic());
+        Attestation res = HelperTest.makeUnsignedx509Att(subjectKeys.getPublic());
         res.setSmartcontracts(Arrays.asList(13L));
         assertFalse(res.isValidX509());
     }
 
     @Test
     public void testExpired() throws Exception {
-        Attestation res = TestHelper.makeUnsignedx509Att(subjectKeys.getPublic());
+        Attestation res = HelperTest.makeUnsignedx509Att(subjectKeys.getPublic());
         assertTrue(res.checkValidity());
         assertTrue(res.isValidX509());
         Date almostNow = new Date(System.currentTimeMillis() - 1000);
@@ -98,14 +98,14 @@ public class TestAttestation {
 
     @Test
     public void testFullDecoding() throws Exception {
-        byte[] encoding = TestHelper.makeMaximalAtt(subjectKeys.getPublic()).getPrehash();
+        byte[] encoding = HelperTest.makeMaximalAtt(subjectKeys.getPublic()).getPrehash();
         Attestation newAtt = new Attestation(encoding);
         assertArrayEquals(encoding, newAtt.getPrehash());
     }
 
     @Test
     public void testMinimalDecoding() throws Exception {
-        byte[] encoding = TestHelper.makeMinimalAtt().getPrehash();
+        byte[] encoding = HelperTest.makeMinimalAtt().getPrehash();
         Attestation newAtt = new Attestation(encoding);
         assertArrayEquals(encoding, newAtt.getPrehash());
     }

--- a/src/test/java/com/alphawallet/attestation/CryptoTest.java
+++ b/src/test/java/com/alphawallet/attestation/CryptoTest.java
@@ -18,7 +18,7 @@ import org.bouncycastle.math.ec.ECPoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestCrypto {
+public class CryptoTest {
   private AsymmetricCipherKeyPair subjectKeys;
   private AsymmetricCipherKeyPair issuerKeys;
   private AsymmetricCipherKeyPair senderKeys;

--- a/src/test/java/com/alphawallet/attestation/HelperTest.java
+++ b/src/test/java/com/alphawallet/attestation/HelperTest.java
@@ -20,7 +20,7 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 
-public class TestHelper {
+public class HelperTest {
   public static final int CHARS_IN_LINE = 65;
 
 

--- a/src/test/java/com/alphawallet/attestation/IdentifierAttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/IdentifierAttestationTest.java
@@ -17,7 +17,7 @@ import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class TestIdentifierAttestation {
+public class IdentifierAttestationTest {
   private static AsymmetricCipherKeyPair subjectKeys;
   private static AsymmetricCipherKeyPair otherKeys;
   private static SecureRandom rand;
@@ -34,7 +34,7 @@ public class TestIdentifierAttestation {
 
   @Test
   public void testFullDecoding() throws Exception {
-    IdentifierAttestation initial = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, mail);
+    IdentifierAttestation initial = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, mail);
     byte[] encoding = initial.getDerEncoding();
     Attestation newAtt = new IdentifierAttestation(encoding);
     assertArrayEquals(encoding, newAtt.getPrehash());
@@ -42,7 +42,7 @@ public class TestIdentifierAttestation {
 
   @Test
   public void testNotStandard() throws Exception {
-    Attestation initial = TestHelper.makeUnsignedx509Att(subjectKeys.getPublic());
+    Attestation initial = HelperTest.makeUnsignedx509Att(subjectKeys.getPublic());
     byte[] encoding = initial.getPrehash();
     try {
       new IdentifierAttestation(encoding);
@@ -54,7 +54,7 @@ public class TestIdentifierAttestation {
 
   @Test
   public void testCannotSet() {
-    IdentifierAttestation initial = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, "otherTest@test.ts");
+    IdentifierAttestation initial = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, "otherTest@test.ts");
     try {
       initial.setSubject("012345678901234567890123456789012345678901234");
       fail();
@@ -77,7 +77,7 @@ public class TestIdentifierAttestation {
 
   @Test
   public void testInvalidSubject() throws Exception {
-    IdentifierAttestation initial = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, mail);
+    IdentifierAttestation initial = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, mail);
     Field field = initial.getClass().getSuperclass().getDeclaredField("subject");
     field.setAccessible(true);
     // Change the subject address
@@ -87,7 +87,7 @@ public class TestIdentifierAttestation {
 
   @Test
   public void testInvalidSignature() throws Exception {
-    IdentifierAttestation initial = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.TEN, mail);
+    IdentifierAttestation initial = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.TEN, mail);
     Field field = initial.getClass().getSuperclass().getDeclaredField("signature");
     field.setAccessible(true);
     // Change the signature identifier
@@ -97,7 +97,7 @@ public class TestIdentifierAttestation {
 
   @Test
   public void testInvalidPublicKey() throws Exception {
-    IdentifierAttestation initial = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, mail);
+    IdentifierAttestation initial = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, mail);
     Field field = initial.getClass().getSuperclass().getDeclaredField("subjectPublicKeyInfo");
     field.setAccessible(true);
     // Change the public key

--- a/src/test/java/com/alphawallet/attestation/ProofOfKnowledgeTest.java
+++ b/src/test/java/com/alphawallet/attestation/ProofOfKnowledgeTest.java
@@ -103,33 +103,4 @@ public class ProofOfKnowledgeTest {
     assertFalse(crypto.verifyEqualityProof(com1, com2, newPok));
   }
 
-
-  @Test
-  public void TestContract()
-  {
-    SmartContract sc = new SmartContract();
-    // TODO @James B this is where we need to use verifyEqualityProof and computeEqualityProof
-    for (int i = 0; i < 30; i++)
-    {
-      byte[] bytes = new byte[32];
-      rand.nextBytes(bytes);
-      BigInteger rVal = new BigInteger(bytes);
-      ProofOfExponent pok = crypto.computeAttestationProof(rVal);
-      assertTrue(crypto.verifyAttestationRequestProof(pok));
-      assertTrue(sc.testEncoding(pok));
-    }
-
-    //now check fail
-    for (int i = 0; i < 5; i++)
-    {
-      byte[] bytes = new byte[32];
-      rand.nextBytes(bytes);
-      BigInteger rVal = new BigInteger(bytes);
-      ProofOfExponent pok = crypto.computeAttestationProof( rVal);
-      assertTrue(crypto.verifyAttestationRequestProof(pok));
-      ProofOfExponent newPok = new ProofOfExponent(pok.getBase(), pok.getRiddle(), pok.getPoint(), pok.getChallenge().add(BigInteger.ONE));
-      assertFalse(sc.testEncoding(newPok));
-    }
-  }
-
 }

--- a/src/test/java/com/alphawallet/attestation/ProofOfKnowledgeTest.java
+++ b/src/test/java/com/alphawallet/attestation/ProofOfKnowledgeTest.java
@@ -14,7 +14,7 @@ import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class TestPoK {
+public class ProofOfKnowledgeTest {
 
   public static final BigInteger SECRET1 = new BigInteger("5848910840846872525745834000448648789786746461");
   public static final BigInteger SECRET2 = new BigInteger("640848948534656666878789789789484891065000");

--- a/src/test/java/com/alphawallet/attestation/SignedAttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/SignedAttestationTest.java
@@ -23,7 +23,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class TestSignedAttestation {
+public class SignedAttestationTest {
   private static AsymmetricCipherKeyPair subjectKeys;
   private static AsymmetricCipherKeyPair issuerKeys;
   private static SecureRandom rand;
@@ -39,7 +39,7 @@ public class TestSignedAttestation {
 
   @Test
   public void testSignAttestation() {
-    Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, "some@mail.com" );
+    Attestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), BigInteger.ONE, "some@mail.com" );
     SignedAttestation signed = new SignedAttestation(att, issuerKeys);
     assertTrue(signed.checkValidity());
     assertTrue(signed.verify());
@@ -49,7 +49,7 @@ public class TestSignedAttestation {
 
   @Test
   public void testDecoding() throws Exception {
-    Attestation att = TestHelper.makeMaximalAtt(subjectKeys.getPublic());
+    Attestation att = HelperTest.makeMaximalAtt(subjectKeys.getPublic());
     SignedAttestation signed = new SignedAttestation(att, issuerKeys);
     assertTrue(SignatureUtility.verify(att.getPrehash(), signed.getSignature(), issuerKeys.getPublic()));
     assertArrayEquals(att.getPrehash(), signed.getUnsignedAttestation().getPrehash());
@@ -60,7 +60,7 @@ public class TestSignedAttestation {
 
   @Test
   public void testX509() throws Exception {
-    Attestation att = TestHelper.makeUnsignedx509Att(subjectKeys.getPublic());
+    Attestation att = HelperTest.makeUnsignedx509Att(subjectKeys.getPublic());
     byte[] toSign = att.getPrehash();
     byte[] digestBytes = new byte[32];
     Digest digest = new SHA256Digest();

--- a/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
+++ b/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
@@ -11,7 +11,7 @@ import com.alphawallet.attestation.AttestedObject;
 import com.alphawallet.attestation.IdentifierAttestation.AttestationType;
 import com.alphawallet.attestation.ProofOfExponent;
 import com.alphawallet.attestation.SignedAttestation;
-import com.alphawallet.attestation.TestHelper;
+import com.alphawallet.attestation.HelperTest;
 import com.alphawallet.attestation.core.AttestationCrypto;
 import com.alphawallet.attestation.core.DERUtility;
 import java.io.IOException;
@@ -56,7 +56,7 @@ public class TestRedeemCheque {
   public void makeAttestedCheque() {
     BigInteger subjectSecret = new BigInteger("42424242");
     BigInteger senderSecret = new BigInteger("112112112");
-    Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), subjectSecret, "test@test.ts" );
+    Attestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), subjectSecret, "test@test.ts" );
     SignedAttestation signed = new SignedAttestation(att, issuerKeys);
     Cheque cheque = new Cheque("test@test.ts", AttestationType.EMAIL, 1000, 3600000, senderKeys, senderSecret);
     attestedCheque = new AttestedObject(cheque, signed, subjectKeys, subjectSecret, senderSecret, crypto);
@@ -213,7 +213,7 @@ public class TestRedeemCheque {
   public void testNegativeConstruction() {
     BigInteger subjectSecret = new BigInteger("42424242");
     BigInteger senderSecret = new BigInteger("112112112");
-    Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), subjectSecret, "something@google.com");
+    Attestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), subjectSecret, "something@google.com");
     SignedAttestation signed = new SignedAttestation(att, issuerKeys);
     // Wrong mail
     Cheque cheque = new Cheque("something@else.com", AttestationType.EMAIL, 1000, 3600000, senderKeys, senderSecret);
@@ -230,7 +230,7 @@ public class TestRedeemCheque {
     BigInteger subjectSecret = new BigInteger("42424242");
     BigInteger senderSecret = new BigInteger("112112112");
     String mail = "something@google.com";
-    Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), subjectSecret, mail);
+    Attestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), subjectSecret, mail);
     SignedAttestation signed = new SignedAttestation(att, issuerKeys);
     Cheque cheque = new Cheque(mail, AttestationType.EMAIL, 1000, 3600000, senderKeys, senderSecret);
     try {

--- a/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
+++ b/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
@@ -10,7 +10,7 @@ import com.alphawallet.attestation.Attestation;
 import com.alphawallet.attestation.AttestedObject;
 import com.alphawallet.attestation.ProofOfExponent;
 import com.alphawallet.attestation.SignedAttestation;
-import com.alphawallet.attestation.TestHelper;
+import com.alphawallet.attestation.HelperTest;
 import com.alphawallet.attestation.core.AttestationCrypto;
 import com.alphawallet.attestation.core.DERUtility;
 import com.alphawallet.attestation.ticket.Ticket.TicketClass;
@@ -61,7 +61,7 @@ public class TestUseTicket {
 
   @BeforeEach
   public void makeAttestedTicket() {
-    Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL );
+    Attestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL );
     SignedAttestation signed = new SignedAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketIssuerKeys, TICKET_SECRET);
     attestedTicket = new AttestedObject<Ticket>(ticket, signed, subjectKeys, ATTESTATION_SECRET, TICKET_SECRET, crypto);
@@ -208,7 +208,7 @@ public class TestUseTicket {
 
   @Test
   public void testNegativeConstruction() {
-    Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
+    Attestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedAttestation signed = new SignedAttestation(att, attestorKeys);
     // Add an extra t in the mail
     Ticket ticket = new Ticket("testt@test.ts", CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
@@ -223,7 +223,7 @@ public class TestUseTicket {
 
   @Test
   public void testNegativeConstruction2() {
-    Attestation att = TestHelper.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
+    Attestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedAttestation signed = new SignedAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
     try {


### PR DESCRIPTION
so that default gradle build doesn't halt on `contractTest`

Now, gradle build works even of the smart contract doesn't. To trigger test with contract, do `gradle integrationTest`

there are only renaming stuff in the PR so you can safely approve it and merge if the two commands works correctly on your PC

`gradle build` should work
`gradle integrationTest` should fail with the testContract problem.
`gradle check` should fail too as it includes integrationTest.

See below.

````
$ gradle build
Configuration on demand is an incubating feature.

BUILD SUCCESSFUL in 1s
5 actionable tasks: 2 executed, 3 up-to-date
a@thinkpad:~/IdeaProjects/attestation$ gradle integrationTest
Configuration on demand is an incubating feature.

> Task :integrationTest

ProofOfKnolwedgeIntegTest > TestContract() FAILED
    org.opentest4j.AssertionFailedError at ProofOfKnolwedgeIntegTest.java:36

1 test completed, 1 failed

> Task :integrationTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':integrationTest'.
> There were failing tests. See the report at: file:///home/a/IdeaProjects/attestation/build/reports/tests/integrationTest/index.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 12s
3 actionable tasks: 2 executed, 1 up-to-date
````