### PR TITLE
Ensure that generated ec keys always uses the smallest possible y value

### DIFF
--- a/src/main/java/com/alphawallet/attestation/core/AttestationCrypto.java
+++ b/src/main/java/com/alphawallet/attestation/core/AttestationCrypto.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.security.Security;
@@ -21,7 +20,6 @@ import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.crypto.params.ECKeyGenerationParameters;
-import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -78,19 +76,6 @@ public class AttestationCrypto {
     byte[] hash = KECCAK.digest();
     //finally get only the last 20 bytes
     return "0x" + Hex.toHexString(Arrays.copyOfRange(hash,hash.length-20,hash.length)).toUpperCase();
-  }
-
-  public AsymmetricCipherKeyPair constructECKeysWithLowestYCoord() {
-    AsymmetricCipherKeyPair keys;
-    BigInteger yCoord;
-    BigInteger fieldModulo = ECDSAdomain.getCurve().getField().getCharacteristic();
-    // If the y coordinate is in the upper half of the field, then sample again until it to the lower half
-    do {
-      keys = constructECKeys();
-      ECPublicKeyParameters pk = (ECPublicKeyParameters) keys.getPublic();
-      yCoord = pk.getQ().getYCoord().toBigInteger();
-    } while (yCoord.compareTo(fieldModulo.shiftRight(1)) > 0);
-    return keys;
   }
 
   public AsymmetricCipherKeyPair constructECKeys() {

--- a/src/main/java/com/alphawallet/attestation/core/AttestationCrypto.java
+++ b/src/main/java/com/alphawallet/attestation/core/AttestationCrypto.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.security.Security;
@@ -20,6 +21,7 @@ import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.crypto.params.ECKeyGenerationParameters;
+import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -76,6 +78,19 @@ public class AttestationCrypto {
     byte[] hash = KECCAK.digest();
     //finally get only the last 20 bytes
     return "0x" + Hex.toHexString(Arrays.copyOfRange(hash,hash.length-20,hash.length)).toUpperCase();
+  }
+
+  public AsymmetricCipherKeyPair constructECKeysWithLowestYCoord() {
+    AsymmetricCipherKeyPair keys;
+    BigInteger yCoord;
+    BigInteger fieldModulo = ECDSAdomain.getCurve().getField().getCharacteristic();
+    // If the y coordinate is in the upper half of the field, then sample again until it to the lower half
+    do {
+      keys = constructECKeys();
+      ECPublicKeyParameters pk = (ECPublicKeyParameters) keys.getPublic();
+      yCoord = pk.getQ().getYCoord().toBigInteger();
+    } while (yCoord.compareTo(fieldModulo.shiftRight(1)) > 0);
+    return keys;
   }
 
   public AsymmetricCipherKeyPair constructECKeys() {

--- a/src/main/java/com/alphawallet/attestation/core/AttestationCryptoWithEthereumCharacteristics.java
+++ b/src/main/java/com/alphawallet/attestation/core/AttestationCryptoWithEthereumCharacteristics.java
@@ -1,0 +1,52 @@
+package com.alphawallet.attestation.core;
+
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.params.ECPublicKeyParameters;
+
+/*
+ * One of the Ethereum design is, instead of verifying a message
+ * against a known public key, a 𝑣 value is included in the signature,
+ * allowing an Ethereum address to be recovered from a message. The
+ * advantage of this design is that message doesn't have to carry the
+ * sender's Etheruem address, yet allowing a smart contract to check
+ * the message against a dictionary of possible senders.
+
+ * For example, Alice sends a cheque for Bob to redeem an ERC20
+ * token. She doesn't need to include her Ethereum address as it can
+ * be determined from the signature; the smart contract, instead of
+ * verifying it against a large array of known users, can use the
+ * recovered Ethereum address to look up the remaining balance.
+
+ * This design is great however it breaks X9.62 key format:
+ * ECDSA-Sig-Value ::= SEQUENCE { r INTEGER, s INTEGER }
+
+ * In the scenario where the public key is known, a smart contract can
+ * simply store the 𝑣 value together with the public key; however, in
+ * other situations, to avoid attepting 𝑣 value 2 times, we can
+ * selectively only use keys which result in a fixed 𝑣 value. This
+ * class replaced the constructECKeys() method just to do that.
+ */
+
+public class AttestationCryptoWithEthereumCharacteristics extends AttestationCrypto {
+    public AttestationCryptoWithEthereumCharacteristics(SecureRandom rand) {
+        super(rand);
+    }
+
+    public AsymmetricCipherKeyPair constructECKeys() {
+        AsymmetricCipherKeyPair keys;
+        BigInteger yCoord;
+        BigInteger fieldModulo = ECDSAdomain.getCurve().getField().getCharacteristic();
+        // If the y coordinate is in the upper half of the field, then sample again until it to the lower half
+        do {
+            keys = super.constructECKeys();
+            ECPublicKeyParameters pk = (ECPublicKeyParameters) keys.getPublic();
+            yCoord = pk.getQ().getYCoord().toBigInteger();
+        } while (yCoord.compareTo(fieldModulo.shiftRight(1)) > 0);
+        return keys;
+    }
+
+}

--- a/src/main/java/com/alphawallet/attestation/demo/Demo.java
+++ b/src/main/java/com/alphawallet/attestation/demo/Demo.java
@@ -5,6 +5,7 @@ import com.alphawallet.attestation.cheque.ChequeDecoder;
 import com.alphawallet.attestation.core.AttestationCrypto;
 import com.alphawallet.attestation.AttestationRequest;
 import com.alphawallet.attestation.cheque.Cheque;
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import com.alphawallet.attestation.core.DERUtility;
 import com.alphawallet.attestation.IdentifierAttestation;
 import com.alphawallet.attestation.IdentifierAttestation.AttestationType;
@@ -35,7 +36,7 @@ import org.bouncycastle.crypto.util.PublicKeyFactory;
 import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 
 public class Demo {
-  static AttestationCrypto crypto = new AttestationCrypto(new SecureRandom());
+  static AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(new SecureRandom());
   public static void main(String args[])  {
     CommandLineParser parser = new DefaultParser();
     CommandLine line;
@@ -142,7 +143,7 @@ public class Demo {
   }
 
   private static void createKeys(AttestationCrypto crypto, String pubDir, String privDir) throws IOException {
-    AsymmetricCipherKeyPair keys = crypto.constructECKeysWithLowestYCoord();
+    AsymmetricCipherKeyPair keys = crypto.constructECKeys();
     SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory
         .createSubjectPublicKeyInfo(keys.getPublic());
     byte[] pub = spki.getEncoded();

--- a/src/main/java/com/alphawallet/attestation/demo/Demo.java
+++ b/src/main/java/com/alphawallet/attestation/demo/Demo.java
@@ -142,7 +142,7 @@ public class Demo {
   }
 
   private static void createKeys(AttestationCrypto crypto, String pubDir, String privDir) throws IOException {
-    AsymmetricCipherKeyPair keys = crypto.constructECKeys();
+    AsymmetricCipherKeyPair keys = crypto.constructECKeysWithLowestYCoord();
     SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory
         .createSubjectPublicKeyInfo(keys.getPublic());
     byte[] pub = spki.getEncoded();

--- a/src/test/java/com/alphawallet/attestation/AttestationRequestTest.java
+++ b/src/test/java/com/alphawallet/attestation/AttestationRequestTest.java
@@ -9,6 +9,8 @@ import com.alphawallet.attestation.IdentifierAttestation.AttestationType;
 import com.alphawallet.attestation.core.AttestationCrypto;
 import java.math.BigInteger;
 import java.security.SecureRandom;
+
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.params.ECKeyParameters;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,8 +25,8 @@ public class AttestationRequestTest {
     SecureRandom rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
 
-    crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeysWithLowestYCoord();
+    crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    subjectKeys = crypto.constructECKeys();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/AttestationRequestTest.java
+++ b/src/test/java/com/alphawallet/attestation/AttestationRequestTest.java
@@ -24,7 +24,7 @@ public class AttestationRequestTest {
     rand.setSeed("seed".getBytes());
 
     crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeys();
+    subjectKeys = crypto.constructECKeysWithLowestYCoord();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/AttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/AttestationTest.java
@@ -12,6 +12,8 @@ import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Date;
+
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
@@ -28,8 +30,8 @@ public class AttestationTest {
     public static void setupKeys() throws Exception {
         rand = SecureRandom.getInstance("SHA1PRNG");
         rand.setSeed("seed".getBytes());
-        AttestationCrypto crypto = new AttestationCrypto(rand);
-        subjectKeys = crypto.constructECKeysWithLowestYCoord();
+        AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+        subjectKeys = crypto.constructECKeys();
     }
 
     @Test

--- a/src/test/java/com/alphawallet/attestation/AttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/AttestationTest.java
@@ -29,7 +29,7 @@ public class AttestationTest {
         rand = SecureRandom.getInstance("SHA1PRNG");
         rand.setSeed("seed".getBytes());
         AttestationCrypto crypto = new AttestationCrypto(rand);
-        subjectKeys = crypto.constructECKeys();
+        subjectKeys = crypto.constructECKeysWithLowestYCoord();
     }
 
     @Test

--- a/src/test/java/com/alphawallet/attestation/CryptoTest.java
+++ b/src/test/java/com/alphawallet/attestation/CryptoTest.java
@@ -13,6 +13,8 @@ import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
+
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.math.ec.ECPoint;
@@ -36,9 +38,9 @@ public class CryptoTest {
     rand.setSeed("seed".getBytes());
 
     crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeysWithLowestYCoord();
-    issuerKeys = crypto.constructECKeysWithLowestYCoord();
-    senderKeys = crypto.constructECKeysWithLowestYCoord();
+    subjectKeys = crypto.constructECKeys();
+    issuerKeys = crypto.constructECKeys();
+    senderKeys = crypto.constructECKeys();
   }
 
   @Test
@@ -57,31 +59,15 @@ public class CryptoTest {
 
   @Test
   public void testECKeyWithLowY() {
-    AttestationCrypto crypto = new AttestationCrypto(rand) {
-      private int counter = 0;
-      @Override
-      public AsymmetricCipherKeyPair constructECKeys() {
-        AsymmetricCipherKeyPair keys = super.constructECKeys();
-          if (counter < 10) {
-            // Ensure that the keys have a large y
-            ECPublicKeyParameters pk = (ECPublicKeyParameters) keys.getPublic();
-            BigInteger yCoord = pk.getQ().getYCoord().toBigInteger();
-            BigInteger fieldModulo = ECDSAdomain.getCurve().getField().getCharacteristic();
-            if (yCoord.compareTo(fieldModulo.shiftRight(1)) <= 0) {
-              pk = new ECPublicKeyParameters(pk.getQ().negate(), pk.getParameters());
-              keys = new AsymmetricCipherKeyPair(pk, keys.getPrivate());
-            }
-          }
-          counter++;
-          return keys;
-      }
-    };
-    AsymmetricCipherKeyPair keys = crypto.constructECKeysWithLowestYCoord();
-    ECPublicKeyParameters pk = (ECPublicKeyParameters) keys.getPublic();
-    BigInteger yCoord = pk.getQ().getYCoord().toBigInteger();
-    BigInteger fieldModulo = AttestationCrypto.ECDSAdomain.getCurve().getField().getCharacteristic();
-    assertTrue(yCoord.compareTo(fieldModulo.shiftRight(1)) <= 0);
-
+    AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    for (int i=0; i<10; i++) {
+      AsymmetricCipherKeyPair keys = crypto.constructECKeys();
+      ECPublicKeyParameters pk = (ECPublicKeyParameters) keys.getPublic();
+      BigInteger yCoord = pk.getQ().getYCoord().toBigInteger();
+      System.out.println(yCoord);
+      BigInteger fieldModulo = AttestationCrypto.ECDSAdomain.getCurve().getField().getCharacteristic();
+      assertTrue(yCoord.compareTo(fieldModulo.shiftRight(1)) <= 0);
+    }
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/IdentifierAttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/IdentifierAttestationTest.java
@@ -8,6 +8,8 @@ import com.alphawallet.attestation.core.AttestationCrypto;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.security.SecureRandom;
+
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -27,9 +29,9 @@ public class IdentifierAttestationTest {
   public static void setupKeys() throws Exception {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
-    AttestationCrypto crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeysWithLowestYCoord();
-    otherKeys = crypto.constructECKeysWithLowestYCoord();
+    AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    subjectKeys = crypto.constructECKeys();
+    otherKeys = crypto.constructECKeys();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/IdentifierAttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/IdentifierAttestationTest.java
@@ -28,8 +28,8 @@ public class IdentifierAttestationTest {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
     AttestationCrypto crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeys();
-    otherKeys = crypto.constructECKeys();
+    subjectKeys = crypto.constructECKeysWithLowestYCoord();
+    otherKeys = crypto.constructECKeysWithLowestYCoord();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/SignedAttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/SignedAttestationTest.java
@@ -33,8 +33,8 @@ public class SignedAttestationTest {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
     AttestationCrypto crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeys();
-    issuerKeys = crypto.constructECKeys();
+    subjectKeys = crypto.constructECKeysWithLowestYCoord();
+    issuerKeys = crypto.constructECKeysWithLowestYCoord();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/SignedAttestationTest.java
+++ b/src/test/java/com/alphawallet/attestation/SignedAttestationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.alphawallet.attestation.core.AttestationCrypto;
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import com.alphawallet.attestation.core.SignatureUtility;
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
@@ -32,9 +33,9 @@ public class SignedAttestationTest {
   public static void setupKeys() throws Exception {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
-    AttestationCrypto crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeysWithLowestYCoord();
-    issuerKeys = crypto.constructECKeysWithLowestYCoord();
+    AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    subjectKeys = crypto.constructECKeys();
+    issuerKeys = crypto.constructECKeys();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/cheque/TestCheque.java
+++ b/src/test/java/com/alphawallet/attestation/cheque/TestCheque.java
@@ -31,7 +31,7 @@ public class TestCheque {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
     AttestationCrypto crypto = new AttestationCrypto(rand);
-    senderKeys = crypto.constructECKeys();
+    senderKeys = crypto.constructECKeysWithLowestYCoord();
   }
 
 

--- a/src/test/java/com/alphawallet/attestation/cheque/TestCheque.java
+++ b/src/test/java/com/alphawallet/attestation/cheque/TestCheque.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.alphawallet.attestation.core.AttestationCrypto;
 import com.alphawallet.attestation.IdentifierAttestation.AttestationType;
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import com.alphawallet.attestation.core.SignatureUtility;
 import com.alphawallet.attestation.core.URLUtility;
 import java.io.IOException;
@@ -30,8 +31,8 @@ public class TestCheque {
   public static void setupKeys() throws Exception {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
-    AttestationCrypto crypto = new AttestationCrypto(rand);
-    senderKeys = crypto.constructECKeysWithLowestYCoord();
+    AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    senderKeys = crypto.constructECKeys();
   }
 
 

--- a/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
+++ b/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
@@ -47,9 +47,9 @@ public class TestRedeemCheque {
     rand.setSeed("seed".getBytes());
 
     crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeys();
-    issuerKeys = crypto.constructECKeys();
-    senderKeys = crypto.constructECKeys();
+    subjectKeys = crypto.constructECKeysWithLowestYCoord();
+    issuerKeys = crypto.constructECKeysWithLowestYCoord();
+    senderKeys = crypto.constructECKeysWithLowestYCoord();
   }
 
   @BeforeEach

--- a/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
+++ b/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
@@ -13,6 +13,7 @@ import com.alphawallet.attestation.ProofOfExponent;
 import com.alphawallet.attestation.SignedAttestation;
 import com.alphawallet.attestation.HelperTest;
 import com.alphawallet.attestation.core.AttestationCrypto;
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import com.alphawallet.attestation.core.DERUtility;
 import java.io.IOException;
 import java.io.InvalidObjectException;
@@ -46,10 +47,10 @@ public class TestRedeemCheque {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
 
-    crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeysWithLowestYCoord();
-    issuerKeys = crypto.constructECKeysWithLowestYCoord();
-    senderKeys = crypto.constructECKeysWithLowestYCoord();
+    crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    subjectKeys = crypto.constructECKeys();
+    issuerKeys = crypto.constructECKeys();
+    senderKeys = crypto.constructECKeys();
   }
 
   @BeforeEach

--- a/src/test/java/com/alphawallet/attestation/ticket/TestTicket.java
+++ b/src/test/java/com/alphawallet/attestation/ticket/TestTicket.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -47,8 +46,8 @@ public class TestTicket {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
     AttestationCrypto crypto = new AttestationCrypto(rand);
-    senderKeys = crypto.constructECKeys();
-    otherKeys = crypto.constructECKeys();
+    senderKeys = crypto.constructECKeysWithLowestYCoord();
+    otherKeys = crypto.constructECKeysWithLowestYCoord();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/ticket/TestTicket.java
+++ b/src/test/java/com/alphawallet/attestation/ticket/TestTicket.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.alphawallet.attestation.core.AttestationCrypto;
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import com.alphawallet.attestation.core.SignatureUtility;
 import com.alphawallet.attestation.core.URLUtility;
 import com.alphawallet.attestation.ticket.Ticket.TicketClass;
@@ -45,9 +46,9 @@ public class TestTicket {
   public static void setupKeys() throws Exception {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
-    AttestationCrypto crypto = new AttestationCrypto(rand);
-    senderKeys = crypto.constructECKeysWithLowestYCoord();
-    otherKeys = crypto.constructECKeysWithLowestYCoord();
+    AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    senderKeys = crypto.constructECKeys();
+    otherKeys = crypto.constructECKeys();
   }
 
   @Test

--- a/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
+++ b/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
@@ -54,9 +54,9 @@ public class TestUseTicket {
     rand.setSeed("seed".getBytes());
 
     crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeys();
-    attestorKeys = crypto.constructECKeys();
-    ticketIssuerKeys = crypto.constructECKeys();
+    subjectKeys = crypto.constructECKeysWithLowestYCoord();
+    attestorKeys = crypto.constructECKeysWithLowestYCoord();
+    ticketIssuerKeys = crypto.constructECKeysWithLowestYCoord();
   }
 
   @BeforeEach

--- a/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
+++ b/src/test/java/com/alphawallet/attestation/ticket/TestUseTicket.java
@@ -12,6 +12,7 @@ import com.alphawallet.attestation.ProofOfExponent;
 import com.alphawallet.attestation.SignedAttestation;
 import com.alphawallet.attestation.HelperTest;
 import com.alphawallet.attestation.core.AttestationCrypto;
+import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import com.alphawallet.attestation.core.DERUtility;
 import com.alphawallet.attestation.ticket.Ticket.TicketClass;
 import java.io.IOException;
@@ -53,10 +54,10 @@ public class TestUseTicket {
     rand = SecureRandom.getInstance("SHA1PRNG");
     rand.setSeed("seed".getBytes());
 
-    crypto = new AttestationCrypto(rand);
-    subjectKeys = crypto.constructECKeysWithLowestYCoord();
-    attestorKeys = crypto.constructECKeysWithLowestYCoord();
-    ticketIssuerKeys = crypto.constructECKeysWithLowestYCoord();
+    crypto = new AttestationCryptoWithEthereumCharacteristics(rand);
+    subjectKeys = crypto.constructECKeys();
+    attestorKeys = crypto.constructECKeys();
+    ticketIssuerKeys = crypto.constructECKeys();
   }
 
   @BeforeEach


### PR DESCRIPTION
Addresses issue #77 
I changed code to always generate ecdsa keys with the lowest of the two possible y coordinates for the public key. This is tested in CryptoTest.testECKeyWithLowY