### PR TITLE
Rejection sampling

### DIFF
--- a/src/main/java/com/alphawallet/attestation/core/AttestationCrypto.java
+++ b/src/main/java/com/alphawallet/attestation/core/AttestationCrypto.java
@@ -43,9 +43,9 @@ public class AttestationCrypto {
   public static final BigInteger cofactor = new BigInteger("1");
   public static final ECCurve curve = new Fp(fieldSize, BigInteger.ZERO, new BigInteger("3"), curveOrder, cofactor);
   // Generator for message part of Pedersen commitments generated deterministically from mapToInteger queried on 0 and mapped to the curve using try-and-increment
-  public static final ECPoint G = curve.createPoint(new BigInteger("12022136709705892117842496518378933837282529509560188557390124672992517127582"), new BigInteger("6765325636686621066142015726326349598074684595222800743368698766652936798612"));
+  public static final ECPoint G = curve.createPoint(new BigInteger("15729599519504045482191519010597390184315499143087863467258091083496429125073"), new BigInteger("1368880882406055711853124887741765079727455879193744504977106900552137574951"));
   // Generator for randomness part of Pedersen commitments generated deterministically from  mapToInteger queried on 1 to the curve using try-and-increment
-  public static final ECPoint H = curve.createPoint(new BigInteger("12263903704889727924109846582336855803381529831687633314439453294155493615168"), new BigInteger("1637819407897162978922461013726819811885734067940976901570219278871042378189"));
+  public static final ECPoint H = curve.createPoint(new BigInteger("10071451177251346351593122552258400731070307792115572537969044314339076126231"), new BigInteger("2894161621123416739138844080004799398680035544501805450971689609134516348045"));
   private final SecureRandom rand;
 
   public AttestationCrypto(SecureRandom rand) {

--- a/src/test/java/com/alphawallet/attestation/core/CryptoTest.java
+++ b/src/test/java/com/alphawallet/attestation/core/CryptoTest.java
@@ -18,6 +18,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.math.ec.ECFieldElement;
+import org.bouncycastle.math.ec.ECFieldElement.Fp;
 import org.bouncycastle.math.ec.ECPoint;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -323,31 +325,32 @@ public class CryptoTest {
 
   /**
    * This test is here to show that we have nothing-up-our-sleeve in picking the generators
-   * @throws Exception
    */
   @Test
-  public void computeGenerators() throws Exception {
+  public void computeGenerators() {
     assertFalse(AttestationCrypto.G.add(AttestationCrypto.G).isInfinity());
     assertFalse(AttestationCrypto.H.add(AttestationCrypto.H).isInfinity());
 
-    Method mapToInteger = AttestationCrypto.class.getDeclaredMethod("mapToInteger", byte[].class);
-    mapToInteger.setAccessible(true);
-
-    byte[] input = new byte[1];
-    input[0] = 0;
-    BigInteger gVal = (BigInteger) mapToInteger.invoke(crypto, input);
+    BigInteger gVal = rejectionSample(BigInteger.ZERO);
     ECPoint g = computePoint(gVal);
     assertEquals(AttestationCrypto.G, g);
     // Check order
     assertTrue(g.multiply(AttestationCrypto.curveOrder).isInfinity());
     assertArrayEquals(g.multiply(AttestationCrypto.curveOrder.subtract(BigInteger.ONE)).normalize().getXCoord().getEncoded(), g.normalize().getXCoord().getEncoded());
-    input[0] = 1;
-    BigInteger hVal = (BigInteger) mapToInteger.invoke(crypto, input);
+
+    BigInteger hVal = rejectionSample(BigInteger.ONE);
     ECPoint h = computePoint(hVal);
     assertEquals(AttestationCrypto.H, h);
     // Check order
     assertTrue(h.multiply(AttestationCrypto.curveOrder).isInfinity());
     assertArrayEquals(h.multiply(AttestationCrypto.curveOrder.subtract(BigInteger.ONE)).normalize().getXCoord().getEncoded(), h.normalize().getXCoord().getEncoded());
+  }
+
+  private BigInteger rejectionSample(BigInteger seed) {
+    do {
+      seed = AttestationCrypto.mapTo256BitInteger(seed.toByteArray());
+    } while (seed.compareTo(AttestationCrypto.curveOrder) >= 0);
+    return seed;
   }
 
   /**


### PR DESCRIPTION
I implemented rejection sampling to ensure that when a user computes a ZK proof, he/she has already done rejection sampling when picking randomness to ensure that the contract can simply use KECCAK256 to restore the challenge value used in the proof.
NOTE: That as a side effect the generator points have also been updated (they don't need to, but I much prefer to have a test in the code base that computes these using our production code to prove to anyone that they have not been constructed maliciously).
However, because of this we also need Oleg to make an update to the JS.
