### PR TITLE
fix: Signable in token/entity not be packaged correctly in the jar fo…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ task packageLibs(type: Jar) {
     fileMode = 0755
 }
 
+// exclude bunch of com/alphawallet/… but include token/entity and Signable class
 task packageAttestation(type: Jar) {
     from compileJava
     from processResources

--- a/build.gradle
+++ b/build.gradle
@@ -110,11 +110,20 @@ task packageLibs(type: Jar) {
 task packageAttestation(type: Jar) {
     from compileJava
     from processResources
-    exclude 'com/alphawallet/attestation/demo'
-    exclude 'com/alphawallet/ethereum/**'
-    exclude 'com/alphawallet/token/**'
-    exclude 'id/attestation/**'
-    exclude 'dk/**'
+    exclude {
+        if(it.relativePath.pathString.startsWith('com/alphawallet/attestation/demo')
+           || it.relativePath.pathString.startsWith('com/alphawallet/ethereum')
+           || it.relativePath.pathString.startsWith('com/alphawallet/token/tools')
+           || it.relativePath.pathString.startsWith('com/alphawallet/token/util')
+           || it.relativePath.pathString.startsWith('id/attestation')
+           || it.relativePath.pathString.startsWith('dk')){
+            return true
+        } else if(!it.directory
+            && it.relativePath.pathString.startsWith('com/alphawallet/token/entity')
+            && it.name != 'Signable.class'){
+            return true
+        }
+    }
     manifest {
         attributes('Implementation-Title': project.name,
                 'Implementation-Version': project.version)


### PR DESCRIPTION
Signable.class is be needed for the jar packaged by `packageAttestation` in build.gradle, otherwise it will show the following error:

```
$gradle run

> Task :backend:compileJava FAILED
注: Creating bean classes for 8 type elements
/Users/foxgem/projects/devcon6/attestation.id/backend/src/main/java/id/attestation/utils/CryptoUtils.java:98: 错误: 无法访问Signable
            att.setIssuer("CN=" + request.getAttestor());
               ^
  找不到com.alphawallet.token.entity.Signable的类文件
注: /Users/foxgem/projects/devcon6/attestation.id/backend/src/main/java/id/attestation/ApiController.java使用了未经检查或不安全的操作。
注: 有关详细信息, 请使用 -Xlint:unchecked 重新编译。
1 个错误

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':backend:compileJava'.
> Compilation failed; see the compiler error output for details.
```