### PR TITLE
Remove 67 lines of code by avoiding the 90s file io API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,14 +107,24 @@ task packageLibs(type: Jar) {
     fileMode = 0755
 }
 
+// exclude bunch of com/alphawallet/… but include token/entity and Signable class
 task packageAttestation(type: Jar) {
     from compileJava
     from processResources
-    exclude 'com/alphawallet/attestation/demo'
-    exclude 'com/alphawallet/ethereum/**'
-    exclude 'com/alphawallet/token/**'
-    exclude 'id/attestation/**'
-    exclude 'dk/**'
+    exclude {
+        if(it.relativePath.pathString.startsWith('com/alphawallet/attestation/demo')
+           || it.relativePath.pathString.startsWith('com/alphawallet/ethereum')
+           || it.relativePath.pathString.startsWith('com/alphawallet/token/tools')
+           || it.relativePath.pathString.startsWith('com/alphawallet/token/util')
+           || it.relativePath.pathString.startsWith('id/attestation')
+           || it.relativePath.pathString.startsWith('dk')){
+            return true
+        } else if(!it.directory
+            && it.relativePath.pathString.startsWith('com/alphawallet/token/entity')
+            && it.name != 'Signable.class'){
+            return true
+        }
+    }
     manifest {
         attributes('Implementation-Title': project.name,
                 'Implementation-Version': project.version)

--- a/src/main/java/com/alphawallet/attestation/core/DERUtility.java
+++ b/src/main/java/com/alphawallet/attestation/core/DERUtility.java
@@ -17,6 +17,7 @@ import org.bouncycastle.util.encoders.Base64Encoder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -104,30 +105,19 @@ public class DERUtility {
     return outstream.toByteArray();
   }
 
-  public static String printDER(byte[] input, String type) {
+  public static byte[] toPEM(byte[] input, String type) {
     try {
       Base64Encoder coder = new Base64Encoder();
       ByteArrayOutputStream outstream = new ByteArrayOutputStream();
       coder.encode(input, 0, input.length, outstream);
       byte[] encodedCert = outstream.toByteArray();
-      StringBuilder builder = new StringBuilder();
-      builder.append("-----BEGIN " + type + "-----\n");
-      addBytes(builder, encodedCert);
-      builder.append("-----END " + type + "-----");
-      return builder.toString();
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream( );
+      outputStream.write(("-----BEGIN " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
+      outputStream.write(encodedCert);
+      outputStream.write(("-----END " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
+      return outputStream.toByteArray();
     } catch (IOException e) {
       throw new RuntimeException(e);
-    }
-  }
-
-  private static void addBytes(StringBuilder builder, byte[] encoding) {
-    int start = 0;
-    while (start < encoding.length) {
-      int end = encoding.length - (start + CHARS_IN_LINE) > 0 ?
-          start + CHARS_IN_LINE : encoding.length;
-      builder.append(new String(Arrays.copyOfRange(encoding, start, end)));
-      builder.append('\n');
-      start += CHARS_IN_LINE;
     }
   }
 }

--- a/src/main/java/com/alphawallet/attestation/core/DERUtility.java
+++ b/src/main/java/com/alphawallet/attestation/core/DERUtility.java
@@ -18,7 +18,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 
 public class DERUtility {

--- a/src/main/java/com/alphawallet/attestation/core/DERUtility.java
+++ b/src/main/java/com/alphawallet/attestation/core/DERUtility.java
@@ -16,8 +16,11 @@ import org.bouncycastle.util.encoders.Base64Encoder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 public class DERUtility {
@@ -104,19 +107,15 @@ public class DERUtility {
     return outstream.toByteArray();
   }
 
-  public static byte[] toPEM(byte[] input, String type) {
-    try {
-      Base64Encoder coder = new Base64Encoder();
-      ByteArrayOutputStream outstream = new ByteArrayOutputStream();
-      coder.encode(input, 0, input.length, outstream);
-      byte[] encodedCert = outstream.toByteArray();
-      ByteArrayOutputStream outputStream = new ByteArrayOutputStream( );
-      outputStream.write(("-----BEGIN " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
-      outputStream.write(encodedCert);
-      outputStream.write(("-----END " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
-      return outputStream.toByteArray();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+  public static void writePEM(byte[] input, String type, OutputStream out) throws IOException {
+      out.write(("-----BEGIN " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
+      new Base64Encoder().encode(input, 0, input.length, out);
+      out.write(("\n-----END " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static void writePEM(byte[] input, String type, Path file) throws IOException {
+    OutputStream out = Files.newOutputStream(file);
+    writePEM(input, type, out);
+    out.close();
   }
 }

--- a/src/main/java/com/alphawallet/attestation/core/DERUtility.java
+++ b/src/main/java/com/alphawallet/attestation/core/DERUtility.java
@@ -12,9 +12,7 @@ import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.util.PrivateKeyFactory;
 import org.bouncycastle.math.ec.ECPoint;
-import org.bouncycastle.util.encoders.Base64Encoder;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
@@ -97,15 +95,8 @@ public class DERUtility {
    */
   public static byte[] restoreBytes(List<String> lines) throws IOException {
     // skip first and last line
-    List<String> arr = lines.subList(1, lines.size()-1);
-    StringBuffer buf = new StringBuffer();
-    for (int i = 0; i < arr.size(); i++) {
-      buf.append(arr.get(i));
-    }
-    Base64Encoder coder = new Base64Encoder();
-    ByteArrayOutputStream outstream = new ByteArrayOutputStream();
-    coder.decode(buf.toString(), outstream);
-    return outstream.toByteArray();
+    String longStr = String.join("", lines.subList(1, lines.size()-1));
+    return Base64.getDecoder().decode(longStr.getBytes(StandardCharsets.UTF_8));
   }
 
   public static void writePEM(byte[] input, String type, OutputStream out) throws IOException {

--- a/src/main/java/com/alphawallet/attestation/core/DERUtility.java
+++ b/src/main/java/com/alphawallet/attestation/core/DERUtility.java
@@ -21,10 +21,12 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 
 public class DERUtility {
   public static final int CHARS_IN_LINE = 65;
+  public static final Base64.Encoder rfc1421Encoder = Base64.getMimeEncoder(64, new byte[] {'\n'});
 
   /**
    * Extact an EC keypair from the DER encoded private key
@@ -108,9 +110,9 @@ public class DERUtility {
   }
 
   public static void writePEM(byte[] input, String type, OutputStream out) throws IOException {
-      out.write(("-----BEGIN " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
-      new Base64Encoder().encode(input, 0, input.length, out);
-      out.write(("\n-----END " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
+    out.write(("-----BEGIN " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
+    out.write(rfc1421Encoder.encode(input));
+    out.write(("\n-----END " + type + "-----\n").getBytes(StandardCharsets.UTF_8));
   }
 
   public static void writePEM(byte[] input, String type, Path file) throws IOException {

--- a/src/main/java/com/alphawallet/attestation/core/DERUtility.java
+++ b/src/main/java/com/alphawallet/attestation/core/DERUtility.java
@@ -89,7 +89,7 @@ public class DERUtility {
 
   /**
    * Restores bytes from a base64 PEM-style DER encoding
-   * @param input The string containing the base64 encoding
+   * @param lines The string list containing the base64 encoding
    * @return the raw DER bytes that are encoded
    */
   public static byte[] restoreBytes(List<String> lines) throws IOException {

--- a/src/main/java/com/alphawallet/attestation/demo/Demo.java
+++ b/src/main/java/com/alphawallet/attestation/demo/Demo.java
@@ -1,20 +1,21 @@
 package com.alphawallet.attestation.demo;
 
-import com.alphawallet.attestation.Attestation;
+import com.alphawallet.attestation.*;
+import com.alphawallet.attestation.IdentifierAttestation.AttestationType;
+import com.alphawallet.attestation.cheque.Cheque;
 import com.alphawallet.attestation.cheque.ChequeDecoder;
 import com.alphawallet.attestation.core.AttestationCrypto;
-import com.alphawallet.attestation.AttestationRequest;
-import com.alphawallet.attestation.cheque.Cheque;
 import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteristics;
 import com.alphawallet.attestation.core.DERUtility;
-import com.alphawallet.attestation.IdentifierAttestation;
-import com.alphawallet.attestation.IdentifierAttestation.AttestationType;
-import com.alphawallet.attestation.ProofOfExponent;
-import com.alphawallet.attestation.AttestedObject;
-import com.alphawallet.attestation.SignedAttestation;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
+import org.apache.commons.cli.*;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.PrivateKeyInfoFactory;
+import org.bouncycastle.crypto.util.PublicKeyFactory;
+import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
@@ -24,19 +25,6 @@ import java.security.SecureRandom;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
-import java.util.Scanner;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
-import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
-import org.bouncycastle.crypto.util.PrivateKeyInfoFactory;
-import org.bouncycastle.crypto.util.PublicKeyFactory;
-import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 
 public class Demo {
   static AttestationCrypto crypto = new AttestationCryptoWithEthereumCharacteristics(new SecureRandom());

--- a/src/main/java/com/alphawallet/attestation/demo/Demo.java
+++ b/src/main/java/com/alphawallet/attestation/demo/Demo.java
@@ -62,7 +62,7 @@ public class Demo {
         case "keys":
           System.out.println("Constructing key pair...");
           try {
-            createKeys(crypto, arguments.get(1), arguments.get(2));
+            createKeys(crypto, Paths.get(arguments.get(1)), Paths.get(arguments.get(2)));
           } catch (Exception e) {
             System.err.println("Was expecting: <output file to public key> <output file to private key>.");
             throw e;
@@ -78,7 +78,7 @@ public class Demo {
             AttestationType type = getType(arguments.get(3));
             long validity = 1000*Long.parseLong(arguments.get(4)); // Validity in milliseconds
             createCheque(crypto, amount, receiverId, type, validity,
-                Paths.get(arguments.get(5)), arguments.get(6), arguments.get(7));
+                Paths.get(arguments.get(5)), Paths.get(arguments.get(6)), Paths.get(arguments.get(7)));
 
           } catch (Exception e) {
             System.err.println("Was expecting: <integer amount to send> <identifier of the receiver> "
@@ -111,7 +111,7 @@ public class Demo {
           System.out.println("Constructing attestation request");
           try {
             AttestationType type = getType(arguments.get(3));
-            requestAttest(crypto, Paths.get(arguments.get(1)), arguments.get(2), type, arguments.get(4), arguments.get(5));
+            requestAttest(crypto, Paths.get(arguments.get(1)), arguments.get(2), type, Paths.get(arguments.get(4)), Paths.get(arguments.get(5)));
           } catch (Exception e) {
             System.err.println("Was expecting: <signing key input dir> <identifier> "
                 + "<type of ID, Either \"mail\" or \"phone\"> <attestation request output dir> <secret output dir>");
@@ -126,7 +126,7 @@ public class Demo {
           System.out.println("Signing attestation...");
           try {
             long validity = 1000*Long.parseLong(arguments.get(3)); // Validity in milliseconds
-            constructAttest(Paths.get(arguments.get(1)), arguments.get(2), validity, Paths.get(arguments.get(4)), arguments.get(5));
+            constructAttest(Paths.get(arguments.get(1)), arguments.get(2), validity, Paths.get(arguments.get(4)), Paths.get(arguments.get(5)));
           } catch (Exception e) {
             System.err.println("Was expecting: <signing key input dir> <issuer name> "
                 + "<validity in seconds> <attestation request input dir> "
@@ -149,41 +149,26 @@ public class Demo {
     System.out.println("SUCCESS!");
   }
 
-  private static void createKeys(AttestationCrypto crypto, String pubFileName, String privateFileName) throws IOException {
+  private static void createKeys(AttestationCrypto crypto, Path pathPubKey, Path pathPrivKey) throws IOException {
     AsymmetricCipherKeyPair keys = crypto.constructECKeys();
     SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory
         .createSubjectPublicKeyInfo(keys.getPublic());
     byte[] pub = spki.getEncoded();
-    if (!writeFile(pubFileName, DERUtility.printDER(pub, "PUBLIC KEY"))) {
-      System.err.println("Could not write public key");
-      throw new IOException("Failed to write file");
-    }
-
+    Files.write(pathPubKey, DERUtility.toPEM(pub, "PUBLIC KEY"));
     PrivateKeyInfo privInfo = PrivateKeyInfoFactory.createPrivateKeyInfo(keys.getPrivate());
-    byte[] priv = privInfo.getEncoded();
-    if (!writeFile(privateFileName, DERUtility.printDER(priv, "PRIVATE KEY"))) {
-      System.err.println("Could not write private key");
-      throw new IOException("Failed to write file");
-    }
+    Files.write(pathPrivKey, DERUtility.toPEM(privInfo.getEncoded(), "CHEQUE"));
   }
 
   private static void createCheque(AttestationCrypto crypto, int amount, String receiverId, AttestationType type,
-      long validityInMilliseconds, Path pathInputKey, String outputDirCheque, String outputDirSecret) throws IOException {
+      long validityInMilliseconds, Path pathInputKey, Path outputDirCheque, Path outputDirSecret) throws IOException {
     AsymmetricCipherKeyPair keys = DERUtility.restoreBase64Keys(Files.readAllLines(pathInputKey));
 
     BigInteger secret = crypto.makeSecret();
     Cheque cheque = new Cheque(receiverId, type, amount, validityInMilliseconds, keys, secret);
     byte[] encoding = cheque.getDerEncoding();
 
-    if (!writeFile(outputDirCheque, DERUtility.printDER(encoding, "CHEQUE"))) {
-      System.err.println("Could not write cheque to disc");
-      throw new IOException("Could not write file");
-    }
-
-    if (!writeFile(outputDirSecret, DERUtility.printDER(DERUtility.encodeSecret(secret), "CHEQUE SECRET"))) {
-      System.err.println("Could not write cheque secret to disc");
-      throw new IOException("Could not write file");
-    }
+    Files.write(outputDirCheque, DERUtility.toPEM(encoding, "CHEQUE"));
+    Files.write(outputDirSecret, DERUtility.toPEM(DERUtility.encodeSecret(secret), "CHEQUE SECRET"));
   }
 
   private static void receiveCheque(Path pathUserKey, Path chequeSecretDir,
@@ -236,25 +221,18 @@ public class Demo {
   }
 
   private static void requestAttest(AttestationCrypto crypto, Path pathUserKey, String receiverId, AttestationType type,
-      String outputDirRequest, String outputDirSecret) throws IOException {
+      Path outputDirRequest, Path outputDirSecret) throws IOException {
     AsymmetricCipherKeyPair keys = DERUtility.restoreBase64Keys(Files.readAllLines(pathUserKey));
     BigInteger secret = crypto.makeSecret();
     ProofOfExponent pok = crypto.computeAttestationProof(secret);
     AttestationRequest request = new AttestationRequest(receiverId, type, pok, keys);
 
-    if (!writeFile(outputDirRequest, DERUtility.printDER(request.getDerEncoding(), "ATTESTATION REQUEST"))) {
-      System.err.println("Could not write attestation request to disc");
-      throw new IOException("Could not write file");
-    }
-
-    if (!writeFile(outputDirSecret, DERUtility.printDER(DERUtility.encodeSecret(secret), "SECRET"))) {
-      System.err.println("Could not write attestation secret to disc");
-      throw new IOException("Could not write file");
-    }
+    Files.write(outputDirRequest, DERUtility.toPEM(request.getDerEncoding(), "ATTESTATION REQUEST"));
+    Files.write(outputDirSecret, DERUtility.toPEM(DERUtility.encodeSecret(secret), "SECRET"));
   }
 
   private static void constructAttest(Path pathAttestorKey, String issuerName,
-      long validityInMilliseconds, Path pathRequest, String attestationDir) throws IOException {
+      long validityInMilliseconds, Path pathRequest, Path attestationDir) throws IOException {
     AsymmetricCipherKeyPair keys = DERUtility.restoreBase64Keys(Files.readAllLines(pathAttestorKey));
     byte[] requestBytes = DERUtility.restoreBytes(Files.readAllLines(pathRequest));
     AttestationRequest request = new AttestationRequest(requestBytes);
@@ -271,10 +249,7 @@ public class Demo {
     att.setNotValidBefore(now);
     att.setNotValidAfter(new Date(System.currentTimeMillis() + validityInMilliseconds));
     SignedAttestation signed = new SignedAttestation(att, keys);
-    if (!writeFile(attestationDir, DERUtility.printDER(signed.getDerEncoding(), "ATTESTATION"))) {
-      System.err.println("Could not write attestation to disc");
-      throw new IOException("Could not write file");
-    }
+    Files.write(attestationDir, DERUtility.toPEM(signed.getDerEncoding(), "ATTESTATION"));
   }
 
   private static AttestationType getType(String stringType) throws IllegalArgumentException {
@@ -292,21 +267,4 @@ public class Demo {
     }
     return type;
   }
-
-  private static boolean writeFile(String file, String data) {
-    try {
-      File file = new File(file);
-      if (!file.createNewFile()) {
-        System.out.println("The output file \"" + file + "\" already exists");
-        return false;
-      }
-      FileWriter writer = new FileWriter(file);
-      writer.write(data);
-      writer.close();
-      return true;
-    } catch (IOException e) {
-      return false;
-    }
-  }
-
 }

--- a/src/main/java/com/alphawallet/attestation/demo/Demo.java
+++ b/src/main/java/com/alphawallet/attestation/demo/Demo.java
@@ -142,9 +142,9 @@ public class Demo {
     SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory
         .createSubjectPublicKeyInfo(keys.getPublic());
     byte[] pub = spki.getEncoded();
-    Files.write(pathPubKey, DERUtility.toPEM(pub, "PUBLIC KEY"));
+    DERUtility.writePEM(pub, "PUBLIC KEY", pathPubKey);
     PrivateKeyInfo privInfo = PrivateKeyInfoFactory.createPrivateKeyInfo(keys.getPrivate());
-    Files.write(pathPrivKey, DERUtility.toPEM(privInfo.getEncoded(), "CHEQUE"));
+    DERUtility.writePEM(privInfo.getEncoded(), "CHEQUE", pathPrivKey);
   }
 
   private static void createCheque(AttestationCrypto crypto, int amount, String receiverId, AttestationType type,
@@ -155,8 +155,8 @@ public class Demo {
     Cheque cheque = new Cheque(receiverId, type, amount, validityInMilliseconds, keys, secret);
     byte[] encoding = cheque.getDerEncoding();
 
-    Files.write(outputDirCheque, DERUtility.toPEM(encoding, "CHEQUE"));
-    Files.write(outputDirSecret, DERUtility.toPEM(DERUtility.encodeSecret(secret), "CHEQUE SECRET"));
+    DERUtility.writePEM(encoding, "CHEQUE", outputDirCheque);
+    DERUtility.writePEM(DERUtility.encodeSecret(secret), "CHEQUE SECRET", outputDirSecret);
   }
 
   private static void receiveCheque(Path pathUserKey, Path chequeSecretDir,
@@ -215,8 +215,8 @@ public class Demo {
     ProofOfExponent pok = crypto.computeAttestationProof(secret);
     AttestationRequest request = new AttestationRequest(receiverId, type, pok, keys);
 
-    Files.write(outputDirRequest, DERUtility.toPEM(request.getDerEncoding(), "ATTESTATION REQUEST"));
-    Files.write(outputDirSecret, DERUtility.toPEM(DERUtility.encodeSecret(secret), "SECRET"));
+    DERUtility.writePEM(request.getDerEncoding(), "ATTESTATION REQUEST", outputDirRequest);
+    DERUtility.writePEM(DERUtility.encodeSecret(secret), "SECRET", outputDirSecret);
   }
 
   private static void constructAttest(Path pathAttestorKey, String issuerName,
@@ -237,7 +237,7 @@ public class Demo {
     att.setNotValidBefore(now);
     att.setNotValidAfter(new Date(System.currentTimeMillis() + validityInMilliseconds));
     SignedAttestation signed = new SignedAttestation(att, keys);
-    Files.write(attestationDir, DERUtility.toPEM(signed.getDerEncoding(), "ATTESTATION"));
+    DERUtility.writePEM(signed.getDerEncoding(), "ATTESTATION", attestationDir);
   }
 
   private static AttestationType getType(String stringType) throws IllegalArgumentException {

--- a/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
+++ b/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
@@ -17,6 +17,7 @@ import com.alphawallet.attestation.core.AttestationCryptoWithEthereumCharacteris
 import com.alphawallet.attestation.core.DERUtility;
 import java.io.IOException;
 import java.io.InvalidObjectException;
+import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.security.PublicKey;
@@ -70,26 +71,25 @@ public class TestRedeemCheque {
         // *** PRINT DER ENCODING OF OBJECTS ***
     try {
       PublicKey pk;
+      PrintStream a = System.out;
       System.out.println("Signed attestation:");
-      System.out.println(DERUtility.toPEM(attestedCheque.getAtt().getDerEncoding(), "SIGNEABLE"));
+      DERUtility.writePEM(attestedCheque.getAtt().getDerEncoding(), "SIGNEABLE", System.out);
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(issuerKeys.getPublic()));
       System.out.println("Attestation verification key:");
-      System.out.println(DERUtility.toPEM(pk.getEncoded(),"PUBLIC KEY"));
-
+      DERUtility.writePEM(pk.getEncoded(),"PUBLIC KEY", System.out);
       System.out.println("Cheque:");
-      System.out.println(DERUtility.toPEM(attestedCheque.getAttestableObject().getDerEncoding(), "CHEQUE"));
+      DERUtility.writePEM(attestedCheque.getAttestableObject().getDerEncoding(), "CHEQUE", System.out);
       System.out.println("Signed cheque verification key:");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(senderKeys.getPublic()));
-      System.out.println(DERUtility.toPEM(pk.getEncoded(),"PUBLIC KEY"));
-
+      DERUtility.writePEM(pk.getEncoded(),"PUBLIC KEY", System.out);
       System.out.println("Attested Cheque:");
-      System.out.println(DERUtility.toPEM(attestedCheque.getDerEncoding(), "REDEEM"));
+      DERUtility.writePEM(attestedCheque.getDerEncoding(), "REDEEM", System.out);
       System.out.println("Signed user public key (for redeem verification):");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(subjectKeys.getPublic()));
-      System.out.println(DERUtility.toPEM(pk.getEncoded(),"PUBLIC KEY"));
+      DERUtility.writePEM(pk.getEncoded(),"PUBLIC KEY", System.out);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
+++ b/src/test/java/com/alphawallet/attestation/cheque/TestRedeemCheque.java
@@ -71,25 +71,25 @@ public class TestRedeemCheque {
     try {
       PublicKey pk;
       System.out.println("Signed attestation:");
-      System.out.println(DERUtility.printDER(attestedCheque.getAtt().getDerEncoding(), "SIGNEABLE"));
+      System.out.println(DERUtility.toPEM(attestedCheque.getAtt().getDerEncoding(), "SIGNEABLE"));
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(issuerKeys.getPublic()));
       System.out.println("Attestation verification key:");
-      System.out.println(DERUtility.printDER(pk.getEncoded(),"PUBLIC KEY"));
+      System.out.println(DERUtility.toPEM(pk.getEncoded(),"PUBLIC KEY"));
 
       System.out.println("Cheque:");
-      System.out.println(DERUtility.printDER(attestedCheque.getAttestableObject().getDerEncoding(), "CHEQUE"));
+      System.out.println(DERUtility.toPEM(attestedCheque.getAttestableObject().getDerEncoding(), "CHEQUE"));
       System.out.println("Signed cheque verification key:");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(senderKeys.getPublic()));
-      System.out.println(DERUtility.printDER(pk.getEncoded(),"PUBLIC KEY"));
+      System.out.println(DERUtility.toPEM(pk.getEncoded(),"PUBLIC KEY"));
 
       System.out.println("Attested Cheque:");
-      System.out.println(DERUtility.printDER(attestedCheque.getDerEncoding(), "REDEEM"));
+      System.out.println(DERUtility.toPEM(attestedCheque.getDerEncoding(), "REDEEM"));
       System.out.println("Signed user public key (for redeem verification):");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(subjectKeys.getPublic()));
-      System.out.println(DERUtility.printDER(pk.getEncoded(),"PUBLIC KEY"));
+      System.out.println(DERUtility.toPEM(pk.getEncoded(),"PUBLIC KEY"));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/org/devcon/ticket/UseTicketTest.java
+++ b/src/test/java/org/devcon/ticket/UseTicketTest.java
@@ -68,26 +68,25 @@ public class UseTicketTest {
     try {
       PublicKey pk;
       System.out.println("Signed attestation:");
-      System.out.println(DERUtility.toPEM(attestedTicket.getAtt().getDerEncoding(), "SIGNABLE"));
+      DERUtility.writePEM(attestedTicket.getAtt().getDerEncoding(), "SIGNABLE", System.out);
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(attestorKeys.getPublic()));
       System.out.println("Attestation verification key:");
-      System.out.println(DERUtility.toPEM(pk.getEncoded(), "PUBLIC KEY"));
+      DERUtility.writePEM(pk.getEncoded(), "PUBLIC KEY", System.out);
 
       System.out.println("Ticket:");
-      System.out.println(
-          DERUtility.toPEM(attestedTicket.getAttestableObject().getDerEncoding(), "TICKET"));
+      DERUtility.writePEM(attestedTicket.getAttestableObject().getDerEncoding(), "TICKET", System.out);
       System.out.println("Signed ticket verification key:");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(ticketIssuerKeys.getPublic()));
-      System.out.println(DERUtility.toPEM(pk.getEncoded(), "PUBLIC KEY"));
+      DERUtility.writePEM(pk.getEncoded(), "PUBLIC KEY", System.out);
 
       System.out.println("Attested Ticket:");
-      System.out.println(DERUtility.toPEM(attestedTicket.getDerEncoding(), "ATTESTED-TICKET"));
+      DERUtility.writePEM(attestedTicket.getDerEncoding(), "ATTESTED-TICKET", System.out);
       System.out.println("Signed user public key (for verification of attested ticket):");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(subjectKeys.getPublic()));
-      System.out.println(DERUtility.toPEM(pk.getEncoded(), "PUBLIC KEY"));
+      DERUtility.writePEM(pk.getEncoded(), "PUBLIC KEY", System.out);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/org/devcon/ticket/UseTicketTest.java
+++ b/src/test/java/org/devcon/ticket/UseTicketTest.java
@@ -68,26 +68,26 @@ public class UseTicketTest {
     try {
       PublicKey pk;
       System.out.println("Signed attestation:");
-      System.out.println(DERUtility.printDER(attestedTicket.getAtt().getDerEncoding(), "SIGNABLE"));
+      System.out.println(DERUtility.toPEM(attestedTicket.getAtt().getDerEncoding(), "SIGNABLE"));
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(attestorKeys.getPublic()));
       System.out.println("Attestation verification key:");
-      System.out.println(DERUtility.printDER(pk.getEncoded(), "PUBLIC KEY"));
+      System.out.println(DERUtility.toPEM(pk.getEncoded(), "PUBLIC KEY"));
 
       System.out.println("Ticket:");
       System.out.println(
-          DERUtility.printDER(attestedTicket.getAttestableObject().getDerEncoding(), "TICKET"));
+          DERUtility.toPEM(attestedTicket.getAttestableObject().getDerEncoding(), "TICKET"));
       System.out.println("Signed ticket verification key:");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(ticketIssuerKeys.getPublic()));
-      System.out.println(DERUtility.printDER(pk.getEncoded(), "PUBLIC KEY"));
+      System.out.println(DERUtility.toPEM(pk.getEncoded(), "PUBLIC KEY"));
 
       System.out.println("Attested Ticket:");
-      System.out.println(DERUtility.printDER(attestedTicket.getDerEncoding(), "ATTESTED-TICKET"));
+      System.out.println(DERUtility.toPEM(attestedTicket.getDerEncoding(), "ATTESTED-TICKET"));
       System.out.println("Signed user public key (for verification of attested ticket):");
       pk = new EC().generatePublic(
           SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(subjectKeys.getPublic()));
-      System.out.println(DERUtility.printDER(pk.getEncoded(), "PUBLIC KEY"));
+      System.out.println(DERUtility.toPEM(pk.getEncoded(), "PUBLIC KEY"));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
By the way I think in the test cases we don't worry overwriting test output files - in fact avoiding overriting makes test ambiguous, since `gradle testClean && gradle test` is expected to write new contents instead of shying away from overwriting.