### PR TITLE
remove URLEncoder in makeLabeledURI

### DIFF
--- a/src/main/java/com/alphawallet/attestation/IdentifierAttestation.java
+++ b/src/main/java/com/alphawallet/attestation/IdentifierAttestation.java
@@ -156,9 +156,14 @@ public class IdentifierAttestation extends Attestation implements Validateable {
     }
   }
 
-  private X500Name makeLabeledURI(String type, String identifier)  {
-    DERUTF8String labelValue = new DERUTF8String(identifier + " " + type);
-    RDN rdn = new RDN(LABELED_URI, labelValue);
+  /**
+   * @param label the label of the URL, similar to what is inside <a>...</a>
+   * @param URL the URL itself, similar to what is in <a href="...">, note that
+   * it should already be URLencoded therefore not containing space
+   */
+  private X500Name makeLabeledURI(String label, String URL)  {
+    DERUTF8String labeledURLValue = new DERUTF8String(URL + " " + label);
+    RDN rdn = new RDN(LABELED_URI, labeledURLValue);
     return new X500Name(new RDN[] {rdn});
   }
 

--- a/src/main/java/com/alphawallet/attestation/IdentifierAttestation.java
+++ b/src/main/java/com/alphawallet/attestation/IdentifierAttestation.java
@@ -157,7 +157,7 @@ public class IdentifierAttestation extends Attestation implements Validateable {
   }
 
   private X500Name makeLabeledURI(String type, String identifier)  {
-    DERUTF8String labelValue = new DERUTF8String(URLEncoder.encode(identifier + " " + type, StandardCharsets.UTF_8));
+    DERUTF8String labelValue = new DERUTF8String(identifier + " " + type);
     RDN rdn = new RDN(LABELED_URI, labelValue);
     return new X500Name(new RDN[] {rdn});
   }


### PR DESCRIPTION
current implementation will cause signing offer (autographnft.io) failed and this change is based on @JamesSmartCell ' advice.