### PR TITLE
Fix statuslog errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ task integrationTest(type: Test) {
 }
 
 shadowJar {
+    transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer)
     manifest {
         attributes 'Main-Class': 'com.alphawallet.attestation.demo.Demo'
     }

--- a/src/main/java/org/devcon/ticket/Issuer.java
+++ b/src/main/java/org/devcon/ticket/Issuer.java
@@ -45,6 +45,12 @@ public class Issuer {
             // will throw up badly if dataASN1 is not instanceof ASN1Sequence
             AsymmetricCipherKeyPair issuerKeyPair= DERUtility.restoreRFC5915Key(dataASN1);
             Ticket ticket = new Ticket(mail, devconID, ticketID, ticketClass, issuerKeyPair, sharedSecret);
+            if (!ticket.checkValidity()) {
+                throw new RuntimeException("Something went wrong and the constructed ticket could not be validated");
+            }
+            if (!ticket.verify()) {
+                throw new RuntimeException("Something went wrong and the constructed ticket could not be verified");
+            }
             String ticketInUrl = new String(Base64.getUrlEncoder().encode(ticket.getDerEncoding()));
             System.out.printf("?ticket=%s&secret=%s&mail=%s", ticketInUrl, sharedSecret.toString(), mail);
         }


### PR DESCRIPTION
This fixes issue #172 
It fixes and issue with the way the shadow jar was constructed using log4j data.
See https://stackoverflow.com/questions/48033792/log4j2-error-statuslogger-unrecognized-conversion-specifier
The fix furthermore include explicitly validating the Ticket constructed to be sure that if the magic link gets printed, it will be valid