### PR TITLE
Attestation NPM 0.3.3

### DIFF
--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/src/Authenticator.ts
+++ b/src/main/javascript/crypto/src/Authenticator.ts
@@ -1,6 +1,6 @@
 import {Ticket} from "./Ticket";
 import {KeyPair, keysArray} from "./libs/KeyPair";
-import {base64ToUint8array, uint8ToBn, uint8tohex, logger, hexStringToUint8, hexStringToBase64} from "./libs/utils";
+import {base64ToUint8array, uint8ToBn, uint8tohex, logger, hexStringToBase64} from "./libs/utils";
 import {SignedIdentifierAttestation} from "./libs/SignedIdentifierAttestation";
 import {AttestedObject} from "./libs/AttestedObject";
 import {AttestationCrypto} from "./libs/AttestationCrypto";
@@ -58,11 +58,7 @@ export class Authenticator {
     {
         let ticket: Ticket;
         let att: SignedIdentifierAttestation;
-
-        for (let i in base64senderPublicKeys){
-            if (typeof base64senderPublicKeys[i] === "string")
-                base64senderPublicKeys[i] = KeyPair.publicFromBase64orPEM(<string>base64senderPublicKeys[i]);
-        }
+        base64senderPublicKeys = KeyPair.parseKeyArrayStrings(base64senderPublicKeys);
 
         try {
             ticket = Ticket.fromBase64(base64ticket, <keysArray>base64senderPublicKeys);
@@ -127,13 +123,13 @@ export class Authenticator {
     }
 
     // TODO: Pass in Ticket schema object
-    static validateUseTicket(proof:string, base64attestorPublicKey:string, base64issuerPublicKey:string, userEthKey:string){
+    static validateUseTicket(proof:string, base64attestorPublicKey:string, base64issuerPublicKeys: {[key: string]: KeyPair|string}, userEthKey:string){
 
         let attestorKey = KeyPair.publicFromBase64(base64attestorPublicKey);
-        let issuerKey = KeyPair.publicFromBase64(base64issuerPublicKey);
+        let issuerKeys = KeyPair.parseKeyArrayStrings(base64issuerPublicKeys);
 
         try {
-            let decodedAttestedObject = AttestedObject.fromBytes(hexStringToUint8(proof), UseToken, attestorKey, Ticket, issuerKey);
+            let decodedAttestedObject = AttestedObject.fromBytes(base64ToUint8array(proof), UseToken, attestorKey, Ticket, issuerKeys);
 
             logger(DEBUGLEVEL.LOW,"Verified attested object");
 

--- a/src/main/javascript/crypto/src/libs/AttestedObject.ts
+++ b/src/main/javascript/crypto/src/libs/AttestedObject.ts
@@ -3,7 +3,7 @@ import {SignedIdentifierAttestation} from "./SignedIdentifierAttestation";
 import {hexStringToArray, logger, uint8toBuffer, uint8tohex} from "./utils";
 import {Asn1Der} from "./DerUtility";
 import {ProofOfExponentInterface} from "./ProofOfExponentInterface";
-import {KeyPair} from "./KeyPair";
+import {KeyPair, keysArray} from "./KeyPair";
 import {AsnParser} from "@peculiar/asn1-schema";
 import {UseToken} from "../asn1/shemas/UseToken";
 import {UsageProofOfExponent} from "./UsageProofOfExponent";
@@ -132,14 +132,14 @@ export class AttestedObject implements ASNEncodable, Verifiable {
         return true;
     }
 
-    static fromBytes<D extends UseToken, T extends AttestableObject>(asn1: Uint8Array, decoder: new () => D, attestorKey: KeyPair, attestable: new () => T, issuerKey: KeyPair): AttestedObject{
+    static fromBytes<D extends UseToken, T extends AttestableObject>(asn1: Uint8Array, decoder: new () => D, attestorKey: KeyPair, attestable: new () => T, issuerKeys: keysArray): AttestedObject{
 
         let attested: D = AsnParser.parse( uint8toBuffer(asn1), decoder);
 
         let me = new this();
 
         me.attestableObject = new attestable();
-        me.attestableObject.fromBytes(attested.signedToken, issuerKey);
+        me.attestableObject.fromBytes(attested.signedToken, issuerKeys);
 
         me.att = SignedIdentifierAttestation.fromBytes(new Uint8Array(attested.attestation), attestorKey);
 

--- a/src/main/javascript/crypto/src/libs/Eip712Validator.ts
+++ b/src/main/javascript/crypto/src/libs/Eip712Validator.ts
@@ -100,9 +100,9 @@ export class Eip712Validator {
         let attestedObjectHex = auth.payload;
 
         let attestorKey = KeyPair.publicFromBase64(XMLconfigData.base64attestorPubKey);
-        let issuerKey = XMLconfigData.base64senderPublicKeys["6"];
+        let issuerKeys = XMLconfigData.base64senderPublicKeys;
 
-        let decodedAttestedObject = AttestedObject.fromBytes(hexStringToUint8(attestedObjectHex), UseToken, attestorKey, Ticket, issuerKey);
+        let decodedAttestedObject = AttestedObject.fromBytes(hexStringToUint8(attestedObjectHex), UseToken, attestorKey, Ticket, issuerKeys);
         return decodedAttestedObject;
     }
 

--- a/src/main/javascript/crypto/src/libs/KeyPair.ts
+++ b/src/main/javascript/crypto/src/libs/KeyPair.ts
@@ -554,4 +554,13 @@ export class KeyPair {
         return output;
     }
 
+    static parseKeyArrayStrings(keys: {[key: string]: KeyPair|string}): keysArray {
+        for (let i in keys){
+            if (typeof keys[i] === "string")
+                keys[i] = KeyPair.publicFromBase64orPEM(<string>keys[i]);
+        }
+
+        return <keysArray>keys;
+    }
+
 }


### PR DESCRIPTION
Fix Github issue #250
- Change AttestedObject::fromBytes & Authenticator::validateTicketProof
  to accept keyArray as required by Ticket::fromBytes.