### PR TITLE
test: adding dumping of generated material for tests in attestation.jar

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  downstream-ci:
+  downstream-attestation_id-ci:
     needs:
       - prerelease
     runs-on: ubuntu-latest
@@ -64,4 +64,18 @@ jobs:
           repo: attestation.id
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           workflow_file_name: frontend-p1.yml
+          client_payload: '{ "attestation_ver": "${{ needs.prerelease.outputs.version }}", "use_github_packages": "true" }'
+
+  downstream-token-negotiator-ci:
+    needs:
+      - prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Downstream CI
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: TokenScript
+          repo: token-negotiator
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          workflow_file_name: tn-p1.yml
           client_payload: '{ "attestation_ver": "${{ needs.prerelease.outputs.version }}", "use_github_packages": "true" }'

--- a/src/test/java/org/devcon/ticket/UseTicketTest.java
+++ b/src/test/java/org/devcon/ticket/UseTicketTest.java
@@ -1,12 +1,22 @@
 package org.devcon.ticket;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import com.alphawallet.ethereum.TicketAttestationReturn;
+import com.alphawallet.token.tools.Numeric;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi.EC;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tokenscript.attestation.*;
+import org.tokenscript.attestation.core.AttestationCrypto;
+import org.tokenscript.attestation.core.DERUtility;
+import org.tokenscript.attestation.core.SignatureUtility;
+import org.tokenscript.attestation.demo.SmartContract;
+
 import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.lang.reflect.Field;
@@ -14,26 +24,9 @@ import java.math.BigInteger;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.function.Function;
 
-import com.alphawallet.token.tools.Numeric;
-import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
-import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
-import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi.EC;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.tokenscript.attestation.Attestation;
-import org.tokenscript.attestation.AttestedObject;
-import org.tokenscript.attestation.HelperTest;
-import org.tokenscript.attestation.IdentifierAttestation;
-import org.tokenscript.attestation.ProofOfExponent;
-import org.tokenscript.attestation.SignedIdentifierAttestation;
-import org.tokenscript.attestation.core.AttestationCrypto;
-import org.tokenscript.attestation.core.DERUtility;
-import org.tokenscript.attestation.core.SignatureUtility;
-import org.tokenscript.attestation.demo.SmartContract;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UseTicketTest {
   private static final String MAIL = "test@test.ts";
@@ -71,23 +64,62 @@ public class UseTicketTest {
 
   @BeforeEach
   public void makeAttestedTicket() {
-    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL );
+    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketIssuerKeys, TICKET_SECRET);
-    attestedTicket = new AttestedObject<Ticket>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
+    attestedTicket = new AttestedObject<>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
     assertTrue(attestedTicket.verify());
     assertTrue(attestedTicket.checkValidity());
   }
 
+  // Write test material to be used in JS testing
   @Test
-  public void testSunshine() {
+  void writeTestMaterial() throws Exception {
+    FileImportExport.storeKey(ticketIssuerKeys.getPublic(), "ticket-issuer-key");
+    Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketIssuerKeys, TICKET_SECRET);
+    FileImportExport.storeMaterial(ticket, "ticket");
+    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
+    FileImportExport.storeKey(attestorKeys.getPublic(), "att-issuer-key");
+    SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
+    FileImportExport.storeMaterial(signed, "signed-att");
+    AttestedObject<Ticket> attestedTicket = new AttestedObject<>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
+    FileImportExport.storeMaterial(attestedTicket, "attested-ticket");
+
+    // Validate loading
+    AsymmetricKeyParameter ticketValidationKey = FileImportExport.loadKey("ticket-issuer-key");
+
+    DevconTicketDecoder ticketDecoder = new DevconTicketDecoder(ticketValidationKey);
+    Ticket decodedTicket = FileImportExport.loadMaterial(ticketDecoder, "ticket");
+    assertTrue(decodedTicket.verify());
+    assertTrue(decodedTicket.checkValidity());
+
+    AsymmetricKeyParameter attValidationKey = FileImportExport.loadKey("att-issuer-key");
+    Function<byte[], SignedIdentifierAttestation> attDec = (input) -> {
+      try {
+        return new SignedIdentifierAttestation(input, attValidationKey);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+    SignedIdentifierAttestation decodedAtt = FileImportExport.loadMaterial(attDec, "signed-att");
+    assertTrue(decodedAtt.verify());
+    assertTrue(decodedAtt.checkValidity());
+
+    AttestedObjectDecoder<Ticket> attestedTicketDecoder = new AttestedObjectDecoder<>(ticketDecoder, attValidationKey);
+    AttestedObject<Ticket> decodedAttestedTicket = FileImportExport.loadMaterial(attestedTicketDecoder, "attested-ticket");
+    assertTrue(decodedAttestedTicket.verify());
+    assertTrue(decodedAttestedTicket.checkValidity());
+  }
+
+  @Test
+  void testSunshine() {
     // *** PRINT DER ENCODING OF OBJECTS ***
     try {
       PublicKey pk;
       System.out.println("Signed attestation:");
       DERUtility.writePEM(attestedTicket.getAtt().getDerEncoding(), "SIGNABLE", System.out);
       pk = new EC().generatePublic(
-          SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(attestorKeys.getPublic()));
+              SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(attestorKeys.getPublic()));
       System.out.println("Attestation verification key:");
       DERUtility.writePEM(pk.getEncoded(), "PUBLIC KEY", System.out);
 
@@ -110,14 +142,14 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testWithUnpredictableNumberBundle() {
-    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL );
+  void testWithUnpredictableNumberBundle() {
+    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketIssuerKeys, TICKET_SECRET);
-    UnpredictableNumberTool unt = new UnpredictableNumberTool(rand, new byte[] { 0x01, 0x02}, "http://www.domain.com");
+    UnpredictableNumberTool unt = new UnpredictableNumberTool(rand, new byte[]{0x01, 0x02}, "http://www.domain.com");
     UnpredictableNumberBundle un = unt.getUnpredictableNumberBundle();
-    AttestedObject<Ticket> attestedTicket = new AttestedObject<Ticket>(ticket, signed,
-        ATTESTATION_SECRET, TICKET_SECRET, un.getNumber().getBytes(), crypto);
+    AttestedObject<Ticket> attestedTicket = new AttestedObject<>(ticket, signed,
+            ATTESTATION_SECRET, TICKET_SECRET, un.getNumber().getBytes(), crypto);
     assertTrue(attestedTicket.verify());
     assertTrue(attestedTicket.checkValidity());
     // Validate the UN is correct
@@ -126,9 +158,9 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testDecoding() throws InvalidObjectException {
-    AttestedObject newAttestedTicket = new AttestedObject(attestedTicket.getDerEncoding(), new DevconTicketDecoder(
-        ticketIssuerKeys.getPublic()), attestorKeys.getPublic());
+  void testDecoding() throws InvalidObjectException {
+    AttestedObject<Ticket> newAttestedTicket = new AttestedObject<>(attestedTicket.getDerEncoding(), new DevconTicketDecoder(
+            ticketIssuerKeys.getPublic()), attestorKeys.getPublic());
     assertTrue(newAttestedTicket.getAttestableObject().verify());
     assertTrue(newAttestedTicket.verify());
     assertTrue(newAttestedTicket.checkValidity());
@@ -136,21 +168,21 @@ public class UseTicketTest {
     assertTrue(AttestationCrypto.verifyEqualityProof(newAttestedTicket.getAtt().getUnsignedAttestation().getCommitment(), newAttestedTicket.getAttestableObject().getCommitment(), newAttestedTicket.getPok()));
 
     assertArrayEquals(attestedTicket.getAttestableObject().getDerEncoding(),
-        newAttestedTicket.getAttestableObject().getDerEncoding());
+            newAttestedTicket.getAttestableObject().getDerEncoding());
     assertArrayEquals(attestedTicket.getAtt().getDerEncoding(), newAttestedTicket.getAtt().getDerEncoding());
     assertArrayEquals(attestedTicket.getPok().getDerEncoding(), newAttestedTicket.getPok().getDerEncoding());
     assertEquals(SignatureUtility.addressFromKey(attestedTicket.getAttestedUserKey()),
-        SignatureUtility.addressFromKey(subjectKeys.getPublic()));
+            SignatureUtility.addressFromKey(subjectKeys.getPublic()));
     assertArrayEquals(attestedTicket.getDerEncoding(), newAttestedTicket.getDerEncoding());
 
-    AttestedObject newConstructor = new AttestedObject(attestedTicket.getAttestableObject(),
-        attestedTicket.getAtt(), attestedTicket.getPok());
+    AttestedObject<Ticket> newConstructor = new AttestedObject<>(attestedTicket.getAttestableObject(),
+            attestedTicket.getAtt(), attestedTicket.getPok());
 
     assertArrayEquals(newConstructor.getDerEncoding(), attestedTicket.getDerEncoding());
   }
 
   @Test
-  public void testSmartContractDecode() throws Exception {
+  void testSmartContractDecode() throws Exception {
     //try building all components
     IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL, 15); //valid for 15 seconds
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
@@ -167,7 +199,7 @@ public class UseTicketTest {
     assertTrue(tar.issuerAddress.equalsIgnoreCase(SignatureUtility.addressFromKey(ticketIssuerKeys.getPublic())));
     assertTrue(tar.attestorAddress.equalsIgnoreCase(SignatureUtility.addressFromKey(attestorKeys.getPublic())));
     assertTrue(tar.attestationValid);
-    assertEquals(Numeric.toBigInt(tar.ticketId), TICKET_ID);
+    assertEquals(TICKET_ID, Numeric.toBigInt(tar.ticketId));
 
     System.out.println("Test passed");
     System.out.println("Creating an attestation which only just expired ...");
@@ -175,6 +207,7 @@ public class UseTicketTest {
     att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL, -19); //expires instantly
     signed = new SignedIdentifierAttestation(att, attestorKeys);
     ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketIssuerKeys, TICKET_SECRET);
+    // TODO this lines causes sporadic failures with issues in the asn1 encoding.
     useTicket = new AttestedObject<>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
 
     tar = contract.callVerifyTicketAttestation(useTicket.getDerEncoding());
@@ -234,14 +267,14 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testRebuildComponents() {
+  void testRebuildComponents() {
     //try building all components
-    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL );
+    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketIssuerKeys, TICKET_SECRET);
     AttestedObject<Ticket> useTicket = new AttestedObject<>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
 
-    AttestedObject<Ticket> newUseTicket = new AttestedObject<Ticket>(useTicket.getDerEncoding(), new DevconTicketDecoder(
+    AttestedObject<Ticket> newUseTicket = new AttestedObject<>(useTicket.getDerEncoding(), new DevconTicketDecoder(
             ticketIssuerKeys.getPublic()), attestorKeys.getPublic());
 
     assertTrue(newUseTicket.getAttestableObject().verify());
@@ -249,7 +282,7 @@ public class UseTicketTest {
     assertTrue(newUseTicket.verify());
     assertTrue(newUseTicket.checkValidity());
 
-    AttestedObject newConstructor = new AttestedObject(this.attestedTicket.getAttestableObject(),
+    AttestedObject<Ticket> newConstructor = new AttestedObject<>(this.attestedTicket.getAttestableObject(),
             this.attestedTicket.getAtt(), this.attestedTicket.getPok());
 
     assertArrayEquals(newConstructor.getDerEncoding(), this.attestedTicket.getDerEncoding());
@@ -260,7 +293,7 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testNegativeAttestation() throws Exception {
+  void testNegativeAttestation() throws Exception {
     Attestation att = attestedTicket.getAtt().getUnsignedAttestation();
     Field field = att.getClass().getSuperclass().getDeclaredField("version");
     field.setAccessible(true);
@@ -276,12 +309,12 @@ public class UseTicketTest {
 
   // Test that the key used to sign the Attested Ticket is the same as attested to
   @Test
-  public void testNegativeUnmatchingKeys() throws Exception {
+  void testNegativeUnmatchingKeys() throws Exception {
     Attestation att = attestedTicket.getAtt().getUnsignedAttestation();
     Field field = att.getClass().getSuperclass().getDeclaredField("subjectPublicKeyInfo");
     field.setAccessible(true);
     SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory
-        .createSubjectPublicKeyInfo(attestorKeys.getPublic());
+            .createSubjectPublicKeyInfo(attestorKeys.getPublic());
     assertFalse(Arrays.equals(spki.getEncoded(), att.getSubjectPublicKeyInfo().getEncoded()));
     // Change public key
     field.set(att, spki);
@@ -295,7 +328,7 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testNegativeDifferentKeys() throws Exception {
+  void testNegativeDifferentKeys() throws Exception {
     SignedIdentifierAttestation att = attestedTicket.getAtt();
     Field field = att.getClass().getDeclaredField("attestationVerificationKey");
     field.setAccessible(true);
@@ -307,10 +340,10 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testNegativeWrongProofIdentifier() throws Exception {
+  void testNegativeWrongProofIdentifier() throws Exception {
     // Wrong attestation secret
     ProofOfExponent newPok = crypto
-        .computeEqualityProof(attestedTicket.getAtt().getUnsignedAttestation().getCommitment(), attestedTicket.getAttestableObject().getCommitment(), new BigInteger("42424242"), TICKET_SECRET);
+            .computeEqualityProof(attestedTicket.getAtt().getUnsignedAttestation().getCommitment(), attestedTicket.getAttestableObject().getCommitment(), new BigInteger("42424242"), TICKET_SECRET);
     Field field = attestedTicket.getClass().getDeclaredField("pok");
     field.setAccessible(true);
     // Change the proof
@@ -324,8 +357,8 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testNegativeWrongRiddle() throws Exception {
-    Ticket newTicket  = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
+  void testNegativeWrongRiddle() throws Exception {
+    Ticket newTicket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
     assertTrue(newTicket.checkValidity());
     assertTrue(newTicket.verify());
     Field field = attestedTicket.getClass().getDeclaredField("attestableObject");
@@ -339,14 +372,14 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testNegativeConstruction() {
+  void testNegativeConstruction() {
     IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
     // Add an extra t in the mail
     Ticket ticket = new Ticket("testt@test.ts", CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
     try {
-      AttestedObject current = new AttestedObject(ticket, signed, ATTESTATION_SECRET,
-          TICKET_SECRET, UN, crypto);
+      AttestedObject<Ticket> current = new AttestedObject<>(ticket, signed, ATTESTATION_SECRET,
+              TICKET_SECRET, UN, crypto);
       fail();
     } catch (RuntimeException e) {
       // Expected not to be able to construct a proof for a wrong email
@@ -354,33 +387,18 @@ public class UseTicketTest {
   }
 
   @Test
-  public void testNegativeConstruction2() {
+  void testNegativeConstruction2() {
     IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(subjectKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, subjectKeys, TICKET_SECRET);
-    try {
-      // Wrong subject secret
-      AttestedObject current = new AttestedObject(ticket, signed,
-          TICKET_SECRET.add(BigInteger.ONE), ATTESTATION_SECRET, UN, crypto);
-      fail();
-    } catch (RuntimeException e) {
-      // Expected not to be able to construct a proof for a wrong secret
-    }
-    try {
-      // Wrong attestation secret
-      AttestedObject current = new AttestedObject(ticket, signed, TICKET_SECRET,
-          ATTESTATION_SECRET.add(BigInteger.ONE), UN, crypto);
-      fail();
-    } catch (RuntimeException e) {
-      // Expected not to be able to construct a proof for a wrong secret
-    }
-    try {
-      // Correlated secrets
-      AttestedObject current = new AttestedObject(ticket, signed,
-          TICKET_SECRET.add(BigInteger.ONE), ATTESTATION_SECRET.add(BigInteger.ONE), UN, crypto);
-      fail();
-    } catch (RuntimeException e) {
-      // Expected not to be able to construct a proof for a wrong secret
-    }
+    // Expected not to be able to construct a proof for a wrong secret
+    assertThrows(RuntimeException.class, () -> new AttestedObject<>(ticket, signed,
+            TICKET_SECRET.add(BigInteger.ONE), ATTESTATION_SECRET, UN, crypto));
+    // Expected not to be able to construct a proof for a wrong secret
+    assertThrows(RuntimeException.class, () -> new AttestedObject<>(ticket, signed, TICKET_SECRET,
+            ATTESTATION_SECRET.add(BigInteger.ONE), UN, crypto));
+    // Expected not to be able to construct a proof for a wrong secret
+    assertThrows(RuntimeException.class, () -> new AttestedObject<>(ticket, signed,
+            TICKET_SECRET.add(BigInteger.ONE), ATTESTATION_SECRET.add(BigInteger.ONE), UN, crypto));
   }
 }

--- a/src/test/java/org/tokenscript/attestation/FileImportExport.java
+++ b/src/test/java/org/tokenscript/attestation/FileImportExport.java
@@ -1,0 +1,124 @@
+package org.tokenscript.attestation;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.PublicKeyFactory;
+import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
+import org.bouncycastle.util.encoders.Base64;
+import org.tokenscript.attestation.core.DERUtility;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.function.Function;
+
+public class FileImportExport {
+    private static final Logger logger = LogManager.getLogger(FileImportExport.class);
+    private static final String rootPath = "build/test-results/";
+
+    /**
+     * Stores a token as a dumb string in file.
+     *
+     * @param token    The string to store.
+     * @param filename The filename to store it under.
+     * @throws Exception If something goes wrong.
+     */
+    public static void storeToken(String token, String filename) throws Exception {
+        OutputStream out = Files.newOutputStream(Paths.get(rootPath + filename + ".txt"));
+        out.write(token.getBytes(StandardCharsets.UTF_8));
+        out.close();
+    }
+
+    /**
+     * Stores an object as a base64 encoded file.
+     *
+     * @param obj      The object to store.
+     * @param filename The filename to use.
+     * @throws Exception If something goes wrong.
+     */
+    public static void storeMaterial(CheckableObject obj, String filename) throws Exception {
+        storeToken(Base64.toBase64String(obj.getDerEncoding()), filename);
+    }
+
+    /**
+     * Loads a token as a dumb string from a file.
+     *
+     * @param filename The file where the token is stored.
+     * @return The content of @filename as a String.
+     * @throws Exception If something goes wrong.
+     */
+    public static String loadToken(String filename) throws Exception {
+        InputStream in = Files.newInputStream(Paths.get(rootPath + filename + ".txt"));
+        byte[] tokenEnc = in.readAllBytes();
+        in.close();
+        return new String(tokenEnc, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Load an object stored in a base64 encoded file.
+     *
+     * @param decoder  A function taking the bytes of the file as input (after base64 decoding) and returns the desired object.
+     * @param filename The name of the file to decode.
+     * @param <T>      The format of the object to decode.
+     * @return The decoded object.
+     * @throws Exception If something goes wrong.
+     */
+    public static <T> T loadMaterial(Function<byte[], T> decoder, String filename) throws Exception {
+        InputStream in = Files.newInputStream(Paths.get(rootPath + filename + ".txt"));
+        byte[] atteEnc = in.readAllBytes();
+        T obj = decoder.apply(Base64.decode(atteEnc));
+        in.close();
+        return obj;
+    }
+
+    /**
+     * Load an object stored in a base64 encoded file using a ObjectDecoder
+     *
+     * @param decoder  The object decoder for the given file.
+     * @param filename The name of the file to decode.
+     * @param <T>      The format of the object to decode.
+     * @return The decoded object.
+     * @throws Exception If something goes wrong.
+     */
+    public static <T extends CheckableObject> T loadMaterial(ObjectDecoder<T> decoder, String filename) throws Exception {
+        Function<byte[], T> func = (input) -> {
+            try {
+                return decoder.decode(input);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+        return loadMaterial(func, filename);
+    }
+
+    /**
+     * Stores a public key as a PEM encoded PKCS compatible SPKI.
+     *
+     * @param validationKey The key to store
+     * @param filename      The file name
+     * @throws Exception If something goes wrong.
+     */
+    public static void storeKey(AsymmetricKeyParameter validationKey, String filename) throws Exception {
+        SubjectPublicKeyInfo spki = SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(validationKey);
+        byte[] pub = spki.getEncoded();
+        DERUtility.writePEM(pub, "PUBLIC KEY", Paths.get(rootPath + filename + ".txt"));
+    }
+
+    /**
+     * Loads a public key stored as a PEM encoded PKCS compatible SPKI.
+     *
+     * @param filename The file name
+     * @throws Exception If something goes wrong.
+     */
+    public static AsymmetricKeyParameter loadKey(String filename) throws Exception {
+        return PublicKeyFactory.createKey
+                (DERUtility.restoreBytes(
+                        Files.readAllLines(
+                                Paths.get(rootPath + filename + ".txt"))));
+    }
+}

--- a/src/test/java/org/tokenscript/attestation/eip712/EIP712ObjectTest.java
+++ b/src/test/java/org/tokenscript/attestation/eip712/EIP712ObjectTest.java
@@ -1,21 +1,9 @@
 package org.tokenscript.attestation.eip712;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-import java.time.Clock;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
-import org.devcon.ticket.Ticket;
 import org.devcon.ticket.DevconTicketDecoder;
+import org.devcon.ticket.Ticket;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,13 +11,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.tokenscript.attestation.AttestedObject;
-import org.tokenscript.attestation.AttestedObjectDecoder;
-import org.tokenscript.attestation.HelperTest;
-import org.tokenscript.attestation.IdentifierAttestation;
-import org.tokenscript.attestation.ObjectDecoder;
-import org.tokenscript.attestation.SignedIdentifierAttestation;
-import org.tokenscript.attestation.Timestamp;
+import org.tokenscript.attestation.*;
 import org.tokenscript.attestation.core.ASNEncodable;
 import org.tokenscript.attestation.core.AttestationCrypto;
 import org.tokenscript.attestation.core.SignatureUtility;
@@ -37,29 +19,32 @@ import org.tokenscript.attestation.core.URLUtility;
 import org.tokenscript.eip712.Eip712Test;
 import org.tokenscript.eip712.FullEip712InternalData;
 
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Clock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 public class EIP712ObjectTest {
   private static final String validatorDomain = "http://www.hotelbogota.com";
 
-  private static final X9ECParameters SECP364R1 = SECNamedCurves.getByName("secp384r1");
   private static final String MAIL = "test@test.ts";
   private static final BigInteger TICKET_ID = new BigInteger("546048445646851568430134455064804806");
   private static final int TICKET_CLASS = 0;  // Regular ticket
   private static final String CONFERENCE_ID = "6";
   private static final BigInteger TICKET_SECRET = new BigInteger("48646");
   private static final BigInteger ATTESTATION_SECRET = new BigInteger("8408464");
-  private static final byte[] UN = new byte[] { 0x42, 0x42 };
+  private static final byte[] UN = new byte[]{0x42, 0x42};
 
   private static AsymmetricCipherKeyPair userKeys, attestorKeys, ticketKeys;
   private static SecureRandom rand;
   private static AttestationCrypto crypto;
-  private static Eip712ObjectValidator validator;
-  private static Eip712ObjectSigner issuer;
+  private static Eip712ObjectValidator<AttestedObject<Ticket>> validator;
+  private static Eip712ObjectSigner<AttestedObject<Ticket>> issuer;
   private static AuthenticatorEncoder encoder;
-
-  @BeforeEach
-  public void init() {
-    MockitoAnnotations.initMocks(this);
-  }
+  @Mock
+  AttestedObject<Ticket> mockedAttestedObject;
 
   @BeforeAll
   public static void setupKeys() throws Exception {
@@ -70,109 +55,136 @@ public class EIP712ObjectTest {
     attestorKeys = SignatureUtility.constructECKeysWithSmallestY(rand);
     ticketKeys = SignatureUtility.constructECKeysWithSmallestY(rand);
     ObjectDecoder<Ticket> ticketDecoder = new DevconTicketDecoder(ticketKeys.getPublic());
-    ObjectDecoder<AttestedObject<Ticket>> attestedObjectDecoder = new AttestedObjectDecoder<Ticket>(ticketDecoder,
-        attestorKeys.getPublic());
+    ObjectDecoder<AttestedObject<Ticket>> attestedObjectDecoder = new AttestedObjectDecoder<>(ticketDecoder,
+            attestorKeys.getPublic());
     encoder = new AuthenticatorEncoder(0, rand);
-    validator = new Eip712ObjectValidator(attestedObjectDecoder, encoder, validatorDomain);
-    issuer = new Eip712ObjectSigner(userKeys.getPrivate(), encoder);
+    validator = new Eip712ObjectValidator<>(attestedObjectDecoder, encoder, validatorDomain);
+    issuer = new Eip712ObjectSigner<>(userKeys.getPrivate(), encoder);
   }
 
   private static AttestedObject<Ticket> makeAttestedTicket() {
-    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(userKeys.getPublic(), attestorKeys.getPublic(), ATTESTATION_SECRET, MAIL );
+    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(userKeys.getPublic(), attestorKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketKeys, TICKET_SECRET);
-    AttestedObject attestedTicket = new AttestedObject<Ticket>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
+    AttestedObject<Ticket> attestedTicket = new AttestedObject<>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
     assertTrue(attestedTicket.verify());
     assertTrue(attestedTicket.checkValidity());
     return attestedTicket;
   }
 
+  @BeforeEach
+  public void init() {
+    MockitoAnnotations.openMocks(this);
+  }
+
   @Test
-  public void legalRequest() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void writeTestMaterial() throws Exception {
+    FileImportExport.storeKey(ticketKeys.getPublic(), "eip712-att-ticket-key");
+    FileImportExport.storeKey(attestorKeys.getPublic(), "eip712-att-issuer-key");
+
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
+    String token = issuer.buildSignedToken(attestedTicket, validatorDomain);
+    FileImportExport.storeToken(token, "eip712-object");
+
+    // Validate loading
+    AsymmetricKeyParameter eip712TicketKey = FileImportExport.loadKey("eip712-att-ticket-key");
+    AsymmetricKeyParameter eip712ValidationKey = FileImportExport.loadKey("eip712-att-issuer-key");
+
+    String decodedToken = FileImportExport.loadToken("eip712-object");
+    ObjectDecoder<Ticket> ticketDecoder = new DevconTicketDecoder(eip712TicketKey);
+    ObjectDecoder<AttestedObject<Ticket>> attestedObjectDecoder = new AttestedObjectDecoder<>(ticketDecoder,
+            eip712ValidationKey);
+    AuthenticatorEncoder encoder = new AuthenticatorEncoder(0, rand);
+    Eip712ObjectValidator<AttestedObject<Ticket>> validator = new Eip712ObjectValidator<>(attestedObjectDecoder, encoder, validatorDomain);
+    validator.validateRequest(decodedToken);
+  }
+
+  @Test
+  void legalRequest() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     String token = issuer.buildSignedToken(attestedTicket, validatorDomain);
     assertTrue(validator.validateRequest(token));
   }
 
   @Test
-  public void eipEncoding() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void eipEncoding() throws Exception {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     String token = issuer.buildSignedToken(attestedTicket, validatorDomain);
     Eip712Test.validateEncoding(encoder, token);
   }
 
   @Test
-  public void eipEncodingDefaultIssuer() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void eipEncodingDefaultIssuer() throws Exception {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     String token = issuer.buildSignedToken(attestedTicket, validatorDomain);
     Eip712Test.validateEncoding(encoder, token);
   }
 
   @Test
-  public void testNewChainID() throws Exception {
+  void testNewChainID() {
     AuthenticatorEncoder localAuthenticator = new AuthenticatorEncoder(42, rand);
-    Eip712ObjectSigner localIssuer = new Eip712ObjectSigner(userKeys.getPrivate(), localAuthenticator);
-    AttestedObject attestedTicket = makeAttestedTicket();
+    Eip712ObjectSigner<AttestedObject<Ticket>> localIssuer = new Eip712ObjectSigner<>(userKeys.getPrivate(), localAuthenticator);
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     String token = localIssuer.buildSignedToken(attestedTicket, validatorDomain);
     ObjectDecoder<Ticket> ticketDecoder = new DevconTicketDecoder(ticketKeys.getPublic());
-    ObjectDecoder<AttestedObject<Ticket>> attestedObjectDecoder = new AttestedObjectDecoder<Ticket>(ticketDecoder,
-        attestorKeys.getPublic());
-    Eip712ObjectValidator localValidator = new Eip712ObjectValidator(attestedObjectDecoder, localAuthenticator,
-        validatorDomain);
+    ObjectDecoder<AttestedObject<Ticket>> attestedObjectDecoder = new AttestedObjectDecoder<>(ticketDecoder,
+            attestorKeys.getPublic());
+    Eip712ObjectValidator<AttestedObject<Ticket>> localValidator = new Eip712ObjectValidator<>(attestedObjectDecoder, localAuthenticator,
+            validatorDomain);
     assertTrue(localValidator.validateRequest(token));
     assertFalse(validator.validateRequest(token));
   }
 
   @Test
-  public void testConsistency() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void testConsistency() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     long testTimestamp = Clock.systemUTC().millis();
-    Eip712ObjectSigner testIssuer = new TestEip712ObjectSigner(userKeys.getPrivate(), new TestAuthenticatorEncoder(), testTimestamp);
+    Eip712ObjectSigner<AttestedObject<Ticket>> testIssuer = new TestEip712ObjectSigner<>(userKeys.getPrivate(), new TestAuthenticatorEncoder(), testTimestamp);
     String token = testIssuer.buildSignedToken(attestedTicket, validatorDomain);
     String newToken = testIssuer.buildSignedToken(attestedTicket, validatorDomain);
     assertEquals(token, newToken);
   }
 
   @Test
-  public void nullInput() {
+  void nullInput() {
     assertFalse(validator.validateRequest(null));
   }
 
   @Test
-  public void wrongAttestedKey() throws Exception {
+  void wrongAttestedKey() {
     AsymmetricCipherKeyPair newKeys = SignatureUtility.constructECKeysWithSmallestY(rand);
-    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(newKeys.getPublic(), attestorKeys.getPublic(), ATTESTATION_SECRET, MAIL );
+    IdentifierAttestation att = HelperTest.makeUnsignedStandardAtt(newKeys.getPublic(), attestorKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation signed = new SignedIdentifierAttestation(att, attestorKeys);
     Ticket ticket = new Ticket(MAIL, CONFERENCE_ID, TICKET_ID, TICKET_CLASS, ticketKeys, TICKET_SECRET);
-    AttestedObject attestedTicket = new AttestedObject<Ticket>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
+    AttestedObject<Ticket> attestedTicket = new AttestedObject<>(ticket, signed, ATTESTATION_SECRET, TICKET_SECRET, UN, crypto);
 
     String token = issuer.buildSignedToken(attestedTicket, validatorDomain);
     assertFalse(validator.validateRequest(token));
   }
 
   @Test
-  public void wrongSignature() throws Exception {
+  void wrongSignature() {
     AsymmetricCipherKeyPair newKeys = SignatureUtility.constructECKeysWithSmallestY(rand);
-    Eip712ObjectSigner newIssuer = new Eip712ObjectSigner(newKeys.getPrivate(), new AuthenticatorEncoder(encoder.getChainId(),rand));
-    AttestedObject attestedTicket = makeAttestedTicket();
+    Eip712ObjectSigner<AttestedObject<Ticket>> newIssuer = new Eip712ObjectSigner<>(newKeys.getPrivate(), new AuthenticatorEncoder(encoder.getChainId(), rand));
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     String token = newIssuer.buildSignedToken(attestedTicket, validatorDomain);
     assertFalse(validator.validateRequest(token));
   }
 
   @Test
-  public void tooNew() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void tooNew() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     long testTimestamp = Clock.systemUTC().millis() + 2 * Timestamp.ALLOWED_ROUNDING;
-    Eip712ObjectSigner testIssuer = new TestEip712ObjectSigner(userKeys.getPrivate(), new TestAuthenticatorEncoder(), testTimestamp);
+    Eip712ObjectSigner<AttestedObject<Ticket>> testIssuer = new TestEip712ObjectSigner<>(userKeys.getPrivate(), new TestAuthenticatorEncoder(), testTimestamp);
     String token = testIssuer.buildSignedToken(attestedTicket, validatorDomain);
     assertFalse(validator.validateRequest(token));
   }
 
   @Test
-  public void tooOld() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void tooOld() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     long testTimestamp = 10000;
-    Eip712ObjectSigner testIssuer = new TestEip712ObjectSigner(userKeys.getPrivate(), new TestAuthenticatorEncoder(), testTimestamp);
+    Eip712ObjectSigner<AttestedObject<Ticket>> testIssuer = new TestEip712ObjectSigner<>(userKeys.getPrivate(), new TestAuthenticatorEncoder(), testTimestamp);
     String token = testIssuer.buildSignedToken(attestedTicket, validatorDomain);
     ObjectDecoder<Ticket> decoder = new DevconTicketDecoder(ticketKeys.getPublic());
     Eip712ObjectValidator newValidator = new Eip712ObjectValidator(decoder, encoder, validatorDomain);
@@ -180,8 +192,8 @@ public class EIP712ObjectTest {
   }
 
   @Test
-  public void incorrectModifiedToken() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void incorrectModifiedToken() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     String token = issuer.buildSignedToken(attestedTicket, validatorDomain);
     byte[] tokenBytes = token.getBytes(StandardCharsets.UTF_8);
     // Flip a bit
@@ -190,98 +202,96 @@ public class EIP712ObjectTest {
   }
 
   @Test
-  public void incorrectDomain() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
+  void incorrectDomain() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
     // Extra a in domain
     String token = issuer.buildSignedToken(attestedTicket, "http://www.hotelbogotaa.com");
     assertFalse(validator.validateRequest(token));
   }
 
   @Test
-  public void invalidDomainVerifier() {
+  void invalidDomainVerifier() {
     ObjectDecoder<Ticket> decoder = new DevconTicketDecoder(ticketKeys.getPublic());
-    assertThrows( RuntimeException.class, () -> {
+    assertThrows(RuntimeException.class, () -> {
       new Eip712ObjectValidator(decoder, encoder, "www.noHttpPrefix.com");
     });
   }
 
   @Test
-  public void invalidDomainIssuer() {
-    AttestedObject attestedTicket = makeAttestedTicket();
-    assertThrows( RuntimeException.class, () -> {
+  void invalidDomainIssuer() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
+    assertThrows(RuntimeException.class, () -> {
       AuthenticatorEncoder authenticator = new AuthenticatorEncoder(1, rand);
-      Eip712ObjectSigner issuer = new Eip712ObjectSigner(userKeys.getPrivate(), authenticator);
+      Eip712ObjectSigner<AttestedObject<Ticket>> issuer = new Eip712ObjectSigner<>(userKeys.getPrivate(), authenticator);
       issuer.buildSignedToken(attestedTicket, "www.noHttpPrefix.com");
     });
   }
 
   @Test
-  public void invalidVersion() throws Exception {
-    AttestedObject attestedTicket = makeAttestedTicket();
-    Eip712ObjectSigner testIssuer = new Eip712ObjectSigner(userKeys.getPrivate(), new TestAuthenticatorEncoder("2.2", encoder.getChainId()));
+  void invalidVersion() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
+    Eip712ObjectSigner<AttestedObject<Ticket>> testIssuer = new Eip712ObjectSigner<>(userKeys.getPrivate(), new TestAuthenticatorEncoder("2.2", encoder.getChainId()));
     String token = testIssuer.buildSignedToken(attestedTicket, validatorDomain);
     assertFalse(validator.validateRequest(token));
   }
 
   @Test
-  public void badDescription() {
-    AttestedObject attestedTicket = makeAttestedTicket();
-    Eip712ObjectSigner testIssuer = new Eip712ObjectSigner(userKeys.getPrivate(),
-        new TestAuthenticatorEncoder(encoder.getVerifyingContract(), encoder.getSalt(),
-            "Wrong description", encoder.getProtocolVersion(), encoder.getChainId()));
+  void badDescription() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
+    Eip712ObjectSigner<AttestedObject<Ticket>> testIssuer = new Eip712ObjectSigner<>(userKeys.getPrivate(),
+            new TestAuthenticatorEncoder(encoder.getVerifyingContract(), encoder.getSalt(),
+                    "Wrong description", encoder.getProtocolVersion(), encoder.getChainId()));
     String token = testIssuer.buildSignedToken(attestedTicket, validatorDomain);
     assertFalse(validator.validateRequest(token));
   }
 
   @Test
-  public void badVerifyingContract() {
-    AttestedObject attestedTicket = makeAttestedTicket();
-    Eip712ObjectSigner testIssuer = new Eip712ObjectSigner(userKeys.getPrivate(),
-        new TestAuthenticatorEncoder("0xDEADBEEF", encoder.getSalt(),
-            "Wrong description", encoder.getProtocolVersion(), encoder.getChainId()));
+  void badVerifyingContract() {
+    AttestedObject<Ticket> attestedTicket = makeAttestedTicket();
+    Eip712ObjectSigner<AttestedObject<Ticket>> testIssuer = new Eip712ObjectSigner<>(userKeys.getPrivate(),
+            new TestAuthenticatorEncoder("0xDEADBEEF", encoder.getSalt(),
+                    "Wrong description", encoder.getProtocolVersion(), encoder.getChainId()));
     String token = testIssuer.buildSignedToken(attestedTicket, validatorDomain);
     assertFalse(validator.validateRequest(token));
   }
-
-  @Mock
-  AttestedObject mockedAttestedObject;
   @Mock
   ObjectDecoder<AttestedObject<Ticket>> mockedDecoder;
+
   @Test
-  public void unvalidatableUnderlyingObject() throws Exception {
+  void unvalidatableUnderlyingObject() throws Exception {
     Mockito.when(mockedAttestedObject.checkValidity()).thenReturn(false);
     Mockito.when(mockedAttestedObject.verify()).thenReturn(true);
-    Mockito.when(mockedAttestedObject.getDerEncoding()).thenReturn(new byte[] {0x42});
+    Mockito.when(mockedAttestedObject.getDerEncoding()).thenReturn(new byte[]{0x42});
     Mockito.when(mockedAttestedObject.getAttestedUserKey()).thenReturn(userKeys.getPublic());
 
     Mockito.when(mockedDecoder.decode(ArgumentMatchers.any())).thenReturn(mockedAttestedObject);
-    Eip712ObjectValidator newValidator = new Eip712ObjectValidator(mockedDecoder, encoder, validatorDomain);
+    Eip712ObjectValidator<AttestedObject<Ticket>> newValidator = new Eip712ObjectValidator<>(mockedDecoder, encoder, validatorDomain);
     String token = issuer.buildSignedToken(mockedAttestedObject, validatorDomain);
     assertFalse(newValidator.validateRequest(token));
   }
 
   @Test
-  public void unverifiableUnderlyingObject() throws Exception {
+  void unverifiableUnderlyingObject() throws Exception {
     Mockito.when(mockedAttestedObject.checkValidity()).thenReturn(true);
     Mockito.when(mockedAttestedObject.verify()).thenReturn(false);
-    Mockito.when(mockedAttestedObject.getDerEncoding()).thenReturn(new byte[] {0x42});
+    Mockito.when(mockedAttestedObject.getDerEncoding()).thenReturn(new byte[]{0x42});
     Mockito.when(mockedAttestedObject.getAttestedUserKey()).thenReturn(userKeys.getPublic());
 
     Mockito.when(mockedDecoder.decode(ArgumentMatchers.any())).thenReturn(mockedAttestedObject);
-    Eip712ObjectValidator newValidator = new Eip712ObjectValidator(mockedDecoder, encoder, validatorDomain);
+    Eip712ObjectValidator<AttestedObject<Ticket>> newValidator = new Eip712ObjectValidator<>(mockedDecoder, encoder, validatorDomain);
     String token = issuer.buildSignedToken(mockedAttestedObject, validatorDomain);
     assertFalse(newValidator.validateRequest(token));
   }
 
   @Test
-  public void consistentSalt() {
+  void consistentSalt() {
     String salt = encoder.getSalt();
     assertNotNull(salt);
     String otherSalt = encoder.getSalt();
     assertEquals(salt, otherSalt);
   }
 
-  private class TestEip712ObjectSigner<T extends ASNEncodable> extends Eip712ObjectSigner<T> {
+  private static class TestEip712ObjectSigner<T extends ASNEncodable> extends Eip712ObjectSigner<T> {
     private final Timestamp testTimestamp;
 
     public TestEip712ObjectSigner(AsymmetricKeyParameter signingKey, AuthenticatorEncoder authenticator, long testTimestamp) {
@@ -294,7 +304,7 @@ public class EIP712ObjectTest {
       try {
         String encodedObject = URLUtility.encodeData(attestedObject.getDerEncoding());
         FullEip712InternalData auth = new FullEip712InternalData(
-            encoder.getUsageValue(), encodedObject, testTimestamp);
+                encoder.getUsageValue(), encodedObject, testTimestamp);
         return buildSignedTokenFromJsonObject(auth, webDomain);
       } catch (Exception e) {
         throw new RuntimeException("", e);
@@ -302,11 +312,11 @@ public class EIP712ObjectTest {
     }
   }
 
-  private class TestAuthenticatorEncoder extends AuthenticatorEncoder {
-    private String protoVersion;
-    private String usageValue;
-    private String salt;
-    private String verifyingContract;
+  private static class TestAuthenticatorEncoder extends AuthenticatorEncoder {
+    private final String protoVersion;
+    private final String usageValue;
+    private final String salt;
+    private final String verifyingContract;
 
     public TestAuthenticatorEncoder() {
       this(encoder.getProtocolVersion(), encoder.getChainId());

--- a/src/test/java/org/tokenscript/attestation/eip712/TestAttestationRequestEip712.java
+++ b/src/test/java/org/tokenscript/attestation/eip712/TestAttestationRequestEip712.java
@@ -1,12 +1,5 @@
 package org.tokenscript.attestation.eip712;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.spy;
-
-import java.math.BigInteger;
-import java.security.SecureRandom;
-import java.util.Objects;
-
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.ECKeyParameters;
@@ -17,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.tokenscript.attestation.AttestationRequest;
+import org.tokenscript.attestation.FileImportExport;
 import org.tokenscript.attestation.FullProofOfExponent;
 import org.tokenscript.attestation.IdentifierAttestation.AttestationType;
 import org.tokenscript.attestation.Timestamp;
@@ -24,7 +18,15 @@ import org.tokenscript.attestation.core.AttestationCrypto;
 import org.tokenscript.attestation.core.SignatureUtility;
 import org.tokenscript.attestation.core.URLUtility;
 import org.tokenscript.attestation.eip712.Eip712AttestationRequestEncoder.AttestationRequestInternalData;
-import org.tokenscript.eip712.*;
+import org.tokenscript.eip712.Eip712Signer;
+import org.tokenscript.eip712.Eip712Test;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.spy;
 
 public class TestAttestationRequestEip712 {
   private static final String DOMAIN = "http://www.hotelbogota.com";
@@ -50,39 +52,54 @@ public class TestAttestationRequestEip712 {
 
   @BeforeEach
   public void init() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
-//  @Test
-  public void validateJSToken() {
+  @Test
+  void writeTestMaterial() throws Exception {
+    byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
+    FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
+    AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
+    Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, MAIL, attRequest, userSigningKey);
+    FileImportExport.storeToken(request.getJsonEncoding(), "eip712-att-req");
+
+    // Validate loading
+    String decodedToken = FileImportExport.loadToken("eip712-att-req");
+    Eip712AttestationRequest req = new Eip712AttestationRequest(DOMAIN, decodedToken);
+    assertTrue(req.checkValidity());
+    assertTrue(req.verify());
+  }
+
+  //  @Test
+  void validateJSToken() {
     // TODO update according to JS impl
     String request = "{\"signatureInHex\":\"0x6e2a95d19eb26e8a01b11d4ea694387a97f64030c880e0fd96b8378b913b4ec1632335d42781185cbd1044e6706eec1d08dafb063f86a47bf19b10faa85e07781c\",\"jsonSigned\":\"{\\\"domain\\\":{\\\"chainId\\\":3,\\\"name\\\":\\\"http://wwww.attestation.id\\\",\\\"version\\\":\\\"0.1\\\"},\\\"message\\\":{\\\"payload\\\":\\\"MIIBLQIBADCCASYEQQQjSSuHoeDrfflLEOw95Vc0kZHB6cz3pxpVsT6wgYXQaB9UHrziOybmB9Og6cD86Du1nP333I3k5vUogUa_9n5NBCADa4wSP3noAIpweaXuCgNJQGWIikjZiisEjFKg7SS_UQRBBAze02glDx9vj1SU6EDo3oNYR-qRam7m_tzhPffMchQgLTEM6Cf1hyytuly5ZfbhTyLKb90cTqw1QIoDIqn8W6AEfAAAAXhA_G5sdH-jiuhdX2vhv-GKUEDz1PufxLdKSXLUQOe9y48bbCgvIdwS3UO9FbhmQzMgQauXAQNX16mVOdMvZKl24jVJjabMI6iY8lztbg-HkIsPKqDcH4B8xdJGAYb3IzySfn2y3McDwOUAtlPKgic7e_rYBF2FpHA=\\\",\\\"description\\\":\\\"Linking Ethereum address to phone or email\\\",\\\"timestamp\\\":\\\"Wed Mar 17 2021 18:19:49 GMT+0200\\\",\\\"identifier\\\":\\\"test@test.com\\\",\\\"address\\\":\\\"0x2f21dc12dd43bd15b86643332041ab97010357d7\\\"},\\\"primaryType\\\":\\\"AttestationRequest\\\",\\\"types\\\":{\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"chainId\\\",\\\"type\\\":\\\"uint256\\\"}],\\\"AttestationRequest\\\":[{\\\"name\\\":\\\"address\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"}]}}\"}";
     Eip712AttestationRequest eiprequest = new Eip712AttestationRequest("http://wwww.attestation.id",
-        request);
+            request);
     assertTrue(eiprequest.verify());
     assertTrue(eiprequest.checkValidity());
   }
 
   @Test
-  public void eipBugFix() {
+  void eipBugFix() {
     String request = "{\"signatureInHex\":\"0x9fe797bff20a1b5904f8589c7af06363b56bb97c4d3aa0f802a8b669645f3efe69ea0fcf3b910b9277dfafc382667552488b4adc8a8eacdbf34835b24ef9541500\",\"jsonSigned\":\"{\\\"types\\\":{\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}],\\\"AttestationRequest\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequest\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIIBAgIBATCB_ARBBCMZ7_4K5jupelJXNctmyd3VvuV9fBMnATo0iEOfgaynL6StRLSmD_qvn_h6l7gyRj6vdg2LF9XCFnXfBqQ2rnEEIA8YIDJ4tN8RK8k0MdE1MKigxk2vrHX9OdnccFQ588zQBEEEDfCh9NDuU-TLojJa-rzBPdNXnkyT5PuZeSYXYNh-h9IV8i8pNS7KzKDuGL6lPHoREq7ZZFo07tvDdZdh-qvl7ARSMFgzRkYxQUVENUU5RkI1QTc1QUEzNEYzMzE2OTQzOEMxM0IzQzE5Qjc2qZU50y9kqXbiNUmNpswjqJjyXO1uD4eQiw8qoNwfgHwAAAF_pyFZfA\\\",\\\"description\\\":\\\"Creating email attestation\\\",\\\"timestamp\\\":\\\"Sun Mar 20 2022 13:40:55 GMT+0200\\\",\\\"identifier\\\":\\\"mah@mah.com\\\"},\\\"domain\\\":{\\\"name\\\":\\\"http://wwww.attestation.id\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
     Eip712AttestationRequest eiprequest = new Eip712AttestationRequest("http://wwww.attestation.id", Timestamp.UNLIMITED,
-        request);
+            request);
     assertTrue(eiprequest.verify());
     assertTrue(eiprequest.checkValidity());
   }
 
   @Test
-  public void referenceJsonFormat() {
+  void referenceJsonFormat() {
     String request = "{\"signatureInHex\":\"0x439cfdc3422621c1a77ad12bdf19e80876ddd7317b59055f352fe8d03a3dabba64c1a628321997b260658b098b490f6455c8724bffa859ec191d248a9e5015de1b\",\"jsonSigned\":\"{\\\"types\\\":{\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}],\\\"AttestationRequest\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequest\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIIBAgIBATCB_ARBBBmSwTCP4VSOr07WYbuIZjR6oUIigLCB-o_ygrN2b2xxHKXEocXBQM3NLqQ5OkRuj0ogmOpKgwn7LhWYWkqNzvMEICJmtJRx1tdMmkl2aurO3CCzauIr2G3rsR0VoUkub2M6BEEECsnXLNQdO2PgaHzQWGWg4KAQ4IvSkn1hPJotLPXMhPIuZeSry7aaOEQt64wyXUolp8an18193r5MKhfZ-E3AjQRSMFg3QTE4MUNCNzI1MDc3NkUxNjc4M0Y5RDNDOTE2NkRFMEY5NUFCMjgzr4crx6TxqXpXW2o9byWM8Ya4h7ATlfLav-aSz8hWQ8YAAAF41bojKA==\\\",\\\"description\\\":\\\"Linking Ethereum address to phone or email\\\",\\\"timestamp\\\":\\\"Thu Apr 15 2021 15:30:49 GMT+0200\\\",\\\"identifier\\\":\\\"test@test.ts\\\"},\\\"domain\\\":{\\\"name\\\":\\\"http://www.hotelbogota.com\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
     Eip712AttestationRequest eiprequest = new Eip712AttestationRequest(DOMAIN, Timestamp.UNLIMITED,
-        request, new Eip712AttestationRequestEncoder(Eip712AttestationRequestEncoder.LEGACY_USAGE_VALUE));
+            request, new Eip712AttestationRequestEncoder(Eip712AttestationRequestEncoder.LEGACY_USAGE_VALUE));
     assertTrue(eiprequest.verify());
     assertTrue(eiprequest.checkValidity());
   }
 
   @Test
-  public void testSunshine() {
+  void testSunshine() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
@@ -92,7 +109,7 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void testDecoding() {
+  void testDecoding() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
@@ -111,19 +128,19 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void testOtherValues() {
+  void testOtherValues() {
     AsymmetricCipherKeyPair otherKeys = SignatureUtility.constructECKeysWithSmallestY(rand);
     byte[] nonce = Nonce.makeNonce(SignatureUtility.addressFromKey(otherKeys.getPublic()), "https://www.othersite.org", new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(new BigInteger("623784673234325341563416"), nonce);
     AttestationRequest attRequest = new AttestationRequest(AttestationType.PHONE, pok);
     Eip712AttestationRequest request = new Eip712AttestationRequest("https://www.othersite.org",
-        "0015058081234", attRequest, otherKeys.getPrivate());
+            "0015058081234", attRequest, otherKeys.getPrivate());
     assertTrue(request.verify());
     assertTrue(request.checkValidity());
   }
 
   @Test
-  public void eipEncoding() throws Exception {
+  void eipEncoding() throws Exception {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
@@ -132,22 +149,23 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void eipSignableEncoding() throws Exception {
+  void eipSignableEncoding() throws Exception {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
     AttestationRequestInternalData data = new AttestationRequestInternalData(
-        encoder.getUsageValue(),
-        MAIL, URLUtility.encodeData(attRequest.getDerEncoding()), new Timestamp());
-    Eip712Signer issuer = new Eip712Signer<AttestationRequestInternalData>(userSigningKey, encoder);
+            encoder.getUsageValue(),
+            MAIL, URLUtility.encodeData(attRequest.getDerEncoding()), new Timestamp());
+    Eip712Signer<AttestationRequestInternalData> issuer = new Eip712Signer<>(userSigningKey, encoder);
     String json = issuer.buildSignedTokenFromJsonObject(data.getSignableVersion(), DOMAIN);
     Eip712Test.validateEncoding(encoder, json);
   }
 
   @Mock
   Eip712AttestationRequestEncoder mockedEncoder;
+
   @Test
-  public void badDescription() {
+  void badDescription() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
@@ -161,12 +179,12 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void automaticDecoder() {
+  void automaticDecoder() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
     Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, Timestamp.DEFAULT_TIME_LIMIT_MS,
-        MAIL, attRequest, userSigningKey, new Eip712AttestationRequestEncoder(Eip712AttestationRequestEncoder.LEGACY_USAGE_VALUE));
+            MAIL, attRequest, userSigningKey, new Eip712AttestationRequestEncoder(Eip712AttestationRequestEncoder.LEGACY_USAGE_VALUE));
     assertTrue(request.verify());
     assertTrue(request.checkValidity());
     Eip712AttestationRequest decodedRequest = Eip712AttestationRequest.decodeAndValidateAttestation(DOMAIN, request.getJsonEncoding());
@@ -176,12 +194,12 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void badDomain() {
+  void badDomain() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
     Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, MAIL,
-        attRequest, userSigningKey);
+            attRequest, userSigningKey);
     assertTrue(request.checkValidity());
     assertTrue(request.verify());
     Eip712AttestationRequest newRequest = new Eip712AttestationRequest("http://www.someOtherDomain.com", request.getJsonEncoding());
@@ -190,74 +208,75 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void invalidDomain() {
+  void invalidDomain() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
-    assertThrows( RuntimeException.class, () ->  new Eip712AttestationRequest("www.noHttpPrefix", MAIL,
-        attRequest, userSigningKey));
+    assertThrows(RuntimeException.class, () -> new Eip712AttestationRequest("www.noHttpPrefix", MAIL,
+            attRequest, userSigningKey));
   }
 
   @Mock
   AttestationRequest mockAttestationRequest;
+
   @Test
-  public void invalidConstructor() {
+  void invalidConstructor() {
     Mockito.when(mockAttestationRequest.getDerEncoding()).thenReturn(null);
-    Exception e = assertThrows( RuntimeException.class, () ->  new Eip712AttestationRequest(DOMAIN, MAIL, mockAttestationRequest,
-        userSigningKey));
-    assertEquals(e.getMessage(), "Could not encode object");
+    Exception e = assertThrows(RuntimeException.class, () -> new Eip712AttestationRequest(DOMAIN, MAIL, mockAttestationRequest,
+            userSigningKey));
+    assertEquals("Could not encode object", e.getMessage());
   }
 
   @Test
-  public void invalidDomainOtherConstructor() {
+  void invalidDomainOtherConstructor() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
     Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, MAIL, attRequest,
-        userSigningKey);
-    assertThrows( RuntimeException.class, () ->  new Eip712AttestationRequest("www.noHttpPrefix", request.getJsonEncoding()));
+            userSigningKey);
+    assertThrows(RuntimeException.class, () -> new Eip712AttestationRequest("www.noHttpPrefix", request.getJsonEncoding()));
   }
 
   @Test
-  public void invalidAttestationRequest() {
+  void invalidAttestationRequest() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     Mockito.when(mockAttestationRequest.verify()).thenReturn(false);
-    Mockito.when(mockAttestationRequest.getDerEncoding()).thenReturn(new byte[] {0x00});
+    Mockito.when(mockAttestationRequest.getDerEncoding()).thenReturn(new byte[]{0x00});
     Mockito.when(mockAttestationRequest.getPok()).thenReturn(pok);
     Mockito.when(mockAttestationRequest.getType()).thenReturn(TYPE);
-    assertThrows( IllegalArgumentException.class, () ->  new Eip712AttestationRequest(DOMAIN, MAIL,
-        mockAttestationRequest, userSigningKey));
+    assertThrows(IllegalArgumentException.class, () -> new Eip712AttestationRequest(DOMAIN, MAIL,
+            mockAttestationRequest, userSigningKey));
   }
 
   @Test
-  public void invalidAttestationRequestOtherConstructor() {
+  void invalidAttestationRequestOtherConstructor() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     Mockito.when(mockAttestationRequest.verify()).thenReturn(false);
-    Mockito.when(mockAttestationRequest.getDerEncoding()).thenReturn(new byte[] {0x00});
+    Mockito.when(mockAttestationRequest.getDerEncoding()).thenReturn(new byte[]{0x00});
     Mockito.when(mockAttestationRequest.getPok()).thenReturn(pok);
     Mockito.when(mockAttestationRequest.getType()).thenReturn(TYPE);
-    assertThrows( IllegalArgumentException.class, () ->  new Eip712AttestationRequest(DOMAIN, MAIL,
-        mockAttestationRequest, userSigningKey));
+    assertThrows(IllegalArgumentException.class, () -> new Eip712AttestationRequest(DOMAIN, MAIL,
+            mockAttestationRequest, userSigningKey));
   }
 
   @Test
-  public void badObject() {
+  void badObject() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
     Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, MAIL,
-        attRequest, userSigningKey);
+            attRequest, userSigningKey);
     String json = request.getJsonEncoding();
     String newJson = json.replace(',', '.');
     Exception e = assertThrows(IllegalArgumentException.class,
-        () -> new Eip712AttestationRequest(DOMAIN, newJson));
-    assertEquals(e.getMessage(), "Could not decode object");
+            () -> new Eip712AttestationRequest(DOMAIN, newJson));
+    assertEquals("Could not decode object", e.getMessage());
   }
 
   @Test
-  public void invalidTimestamp() {
+  void invalidTimestamp() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp(10000));
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
@@ -266,46 +285,46 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void invalidDomainConstructor() {
+  void invalidDomainConstructor() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
     Exception e = assertThrows(IllegalArgumentException.class,
-        () -> new Eip712AttestationRequest("www.nohttp.com", MAIL,
-            attRequest, userSigningKey));
-    assertEquals(e.getMessage(), "Issuer domain is not a valid domain");
+            () -> new Eip712AttestationRequest("www.nohttp.com", MAIL,
+                    attRequest, userSigningKey));
+    assertEquals("Issuer domain is not a valid domain", e.getMessage());
   }
 
   @Test
-  public void invalidNonce() {
+  void invalidNonce() {
     byte[] wrongNonce = Nonce.makeNonce(userAddress, "http://www.notTheRightHotel.com", new Timestamp());
     FullProofOfExponent wrongPok = crypto.computeAttestationProof(ATTESTATION_SECRET, wrongNonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, wrongPok);
     Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, MAIL, attRequest,
-        userSigningKey);
+            userSigningKey);
     assertTrue(request.verify());
     assertFalse(request.checkValidity());
   }
 
   @Test
-  public void invalidEncoder() {
+  void invalidEncoder() {
     byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     AttestationRequest attRequest = new AttestationRequest(TYPE, pok);
     Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, Timestamp.DEFAULT_TIME_LIMIT_MS,
-        MAIL, attRequest, userSigningKey, new Eip712AttestationRequestEncoder(Eip712AttestationRequestEncoder.LEGACY_USAGE_VALUE));
+            MAIL, attRequest, userSigningKey, new Eip712AttestationRequestEncoder(Eip712AttestationRequestEncoder.LEGACY_USAGE_VALUE));
     assertTrue(request.verify());
     assertTrue(request.checkValidity());
     // Decode with wrong encoder
     Eip712AttestationRequest decodedRequest = new Eip712AttestationRequest(DOMAIN, Timestamp.DEFAULT_TIME_LIMIT_MS,
-        // Notice the usage of LISCON_USAGE_VALUE instead of LEGACY_USAGE_VALUE
+            // Notice the usage of LISCON_USAGE_VALUE instead of LEGACY_USAGE_VALUE
         request.getJsonEncoding(), new Eip712AttestationRequestEncoder(Eip712AttestationRequestEncoder.LISCON_USAGE_VALUE));
     assertTrue(decodedRequest.verify());
     assertFalse(decodedRequest.checkValidity());
   }
 
   @Test
-  public void wrongSignature() throws Exception {
+  void wrongSignature() {
     String jsonInvalidSig = "{\"signatureInHex\":\"0x4aa618e4587c440340df460c5a6d0fca9e6456533ac260806d38a9ed84e9e5d50f4688b715fcc3bccbd14bd41aa60fbe084c2e8cb3f56d525d4ae1fa3b3b20611c\",\"jsonSigned\":\"{\\\"types\\\":{\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}],\\\"AttestationRequest\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequest\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIIBAgIBATCB_ARBBBmSwTCP4VSOr07WYbuIZjR6oUIigLCB-o_ygrN2b2xxHKXEocXBQM3NLqQ5OkRuj0ogmOpKgwn7LhWYWkqNzvMEICaCnpQT7bEA57OooelM02iKnjo0wxde1NBUrC1MNttoBEEECsnXLNQdO2PgaHzQWGWg4KAQ4IvSkn1hPJotLPXMhPIuZeSry7aaOEQt64wyXUolp8an18193r5MKhfZ-E3AjQRSMFg3QTE4MUNCNzI1MDc3NkUxNjc4M0Y5RDNDOTE2NkRFMEY5NUFCMjgzr4crx6TxqXpXW2o9byWM8Ya4h7ATlfLav-aSz8hWQ8YAAAGA4XN1kA==\\\",\\\"description\\\":\\\"Creating email attestation\\\",\\\"timestamp\\\":\\\"Fri May 20 2022 12:31:22 GMT+0000\\\",\\\"identifier\\\":\\\"test@test.ts\\\"},\\\"domain\\\":{\\\"name\\\":\\\"http://www.hotelbogota.com\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
     Eip712AttestationRequest newRequest = new Eip712AttestationRequest(DOMAIN, Timestamp.UNLIMITED, jsonInvalidSig);
     assertTrue(newRequest.verify());
@@ -314,16 +333,16 @@ public class TestAttestationRequestEip712 {
   }
 
   @Test
-  public void checkKeyRecovery() {
+  void checkKeyRecovery() {
     // Request with modified signature but signed with "userSigningKey"
     String jsonInvalidSig = "{\"signatureInHex\":\"0x4aa618e4587c440340df460c5a6d0fca9e6456533ac260806d38a9ed84e9e5d50f4688b715fcc3bccbd14bd41aa60fbe084c2e8cb3f56d525d4ae1fa3b3b20611c\",\"jsonSigned\":\"{\\\"types\\\":{\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}],\\\"AttestationRequest\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequest\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIIBAgIBATCB_ARBBBmSwTCP4VSOr07WYbuIZjR6oUIigLCB-o_ygrN2b2xxHKXEocXBQM3NLqQ5OkRuj0ogmOpKgwn7LhWYWkqNzvMEICaCnpQT7bEA57OooelM02iKnjo0wxde1NBUrC1MNttoBEEECsnXLNQdO2PgaHzQWGWg4KAQ4IvSkn1hPJotLPXMhPIuZeSry7aaOEQt64wyXUolp8an18193r5MKhfZ-E3AjQRSMFg3QTE4MUNCNzI1MDc3NkUxNjc4M0Y5RDNDOTE2NkRFMEY5NUFCMjgzr4crx6TxqXpXW2o9byWM8Ya4h7ATlfLav-aSz8hWQ8YAAAGA4XN1kA==\\\",\\\"description\\\":\\\"Creating email attestation\\\",\\\"timestamp\\\":\\\"Fri May 20 2022 12:31:22 GMT+0000\\\",\\\"identifier\\\":\\\"test@test.ts\\\"},\\\"domain\\\":{\\\"name\\\":\\\"http://www.hotelbogota.com\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
     Eip712AttestationRequest request = new Eip712AttestationRequest(DOMAIN, Timestamp.UNLIMITED, jsonInvalidSig);
-    AsymmetricKeyParameter candidateKey = request.retrieveUserPublicKey(request.getJsonEncoding(),  AttestationRequestInternalData.class);
+    AsymmetricKeyParameter candidateKey = request.retrieveUserPublicKey(request.getJsonEncoding(), AttestationRequestInternalData.class);
     assertNotEquals(userAddress, SignatureUtility.addressFromKey(candidateKey));
   }
 
   @Test
-  public void validateWrongNonceKey() {
+  void validateWrongNonceKey() {
     // Notice the wrong address
     byte[] nonce = Nonce.makeNonce("0x1234567890123456789012345678901234567890", DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);

--- a/src/test/java/org/tokenscript/attestation/eip712/TestAttestationRequestWithUsageEip712.java
+++ b/src/test/java/org/tokenscript/attestation/eip712/TestAttestationRequestWithUsageEip712.java
@@ -1,17 +1,5 @@
 package org.tokenscript.attestation.eip712;
 
-import org.tokenscript.attestation.AttestationRequest;
-import org.tokenscript.attestation.AttestationRequestWithUsage;
-import org.tokenscript.attestation.FullProofOfExponent;
-import org.tokenscript.attestation.IdentifierAttestation.AttestationType;
-import org.tokenscript.attestation.Timestamp;
-import org.tokenscript.attestation.core.AttestationCrypto;
-import org.tokenscript.attestation.core.SignatureUtility;
-import org.tokenscript.attestation.core.URLUtility;
-import org.tokenscript.attestation.eip712.Eip712AttestationRequestWithUsageEncoder.AttestationRequestWUsageData;
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
@@ -26,8 +14,21 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.tokenscript.attestation.AttestationRequestWithUsage;
+import org.tokenscript.attestation.FileImportExport;
+import org.tokenscript.attestation.FullProofOfExponent;
+import org.tokenscript.attestation.IdentifierAttestation.AttestationType;
+import org.tokenscript.attestation.Timestamp;
+import org.tokenscript.attestation.core.AttestationCrypto;
+import org.tokenscript.attestation.core.SignatureUtility;
+import org.tokenscript.attestation.core.URLUtility;
+import org.tokenscript.attestation.eip712.Eip712AttestationRequestWithUsageEncoder.AttestationRequestWUsageData;
 import org.tokenscript.eip712.Eip712Signer;
 import org.tokenscript.eip712.Eip712Test;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,19 +40,17 @@ public class TestAttestationRequestWithUsageEip712 {
   private static final BigInteger ATTESTATION_SECRET = new BigInteger("15816808484023");
   private static final Eip712AttestationRequestWithUsageEncoder encoder = new Eip712AttestationRequestWithUsageEncoder();
 
-  private static byte[] nonce;
   private static FullProofOfExponent pok;
   private static AttestationRequestWithUsage requestWithUsage;
   private static AsymmetricCipherKeyPair attestorKeys;
   private static AsymmetricKeyParameter userSigningKey;
   private static AsymmetricKeyParameter sessionKey;
   private static String userAddress;
-  private static SecureRandom rand;
   private static AttestationCrypto crypto;
 
   @BeforeAll
   public static void setupKeys() throws Exception {
-    rand = SecureRandom.getInstance("SHA1PRNG", "SUN");
+    SecureRandom rand = SecureRandom.getInstance("SHA1PRNG", "SUN");
     rand.setSeed("seed".getBytes());
     crypto = new AttestationCrypto(rand);
     attestorKeys = SignatureUtility.constructECKeysWithSmallestY(rand);
@@ -60,7 +59,7 @@ public class TestAttestationRequestWithUsageEip712 {
     X9ECParameters SECT283K1 = SECNamedCurves.getByName("sect283k1");
     sessionKey = SignatureUtility.constructECKeys(SECT283K1, rand).getPublic();
     userAddress = SignatureUtility.addressFromKey(userKeys.getPublic());
-    nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
+    byte[] nonce = Nonce.makeNonce(userAddress, DOMAIN, new Timestamp());
     pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     requestWithUsage = new AttestationRequestWithUsage(TYPE, pok, sessionKey);
     assertTrue(requestWithUsage.verify());
@@ -68,19 +67,33 @@ public class TestAttestationRequestWithUsageEip712 {
 
   @BeforeEach
   public void init() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test
-  public void referenceJsonFormat() {
-   String request = "{\"signatureInHex\":\"0x81dcaa2cacd85a2cb731660778cfef76b0261423476d03b215638351cc14882b5dc29ef45402c61872cf63b54c30788041e7624c440b002780d569fc4fd1dd8e1b\",\"jsonSigned\":\"{\\\"types\\\":{\\\"AttestationRequestWUsage\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"expirationTime\\\",\\\"type\\\":\\\"string\\\"}],\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequestWUsage\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIICTQIBATCB_ARBBB62SP-dgZtAemxY0nl4cjxOW0UKyYmDPOz2_YfDFgzeCa3ZVleOniCjeTfuoR9NTatdcoM4IruwzSUv-DniQbcEICIO6_fhc4D0RJEKC1yB3LGvEoXAatK60lC-ipFW-Y26BEEEDFVwBw77_sz-3PcHsmrwCbfzlcYJpvrh1dcYJCcxAAQlgxlEE72jadyvtgoUs-ttKmV-pQN0FXiBiBgU0q9vswRSMFg1RjdCRkU3NTJBQzFBNDVGNjc0OTdEOURDREQ5QkJEQTUwQTgzOTU1Sm1UC7EZ7FbQ1gD2qvRqimx8roUC_TlKlL_iMtn-uNsAAAF7FWOBwDCCAUcwgfgGByqGSM49AgEwgewCAQEwJQYHKoZIzj0BAjAaAgIBGwYJKoZIzj0BAgMDMAkCAQUCAQcCAQwwTAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEESQQFAyE_eMpEiD8aO4Fi8YjlU80mXyPBVnoWh2kTsMKsJFhJKDYBzNo4DxyeMY2Q-V0H5UJv6H5FwOgYRpjkWWI2TjQRYXfdIlkCJAH______________________-muLtB1dyZd_3-URR4GHhY8YQIBBANKAAQFK7J9i33xUcv3NBo2Xh82NNDkiqCBaefEwx4sRgxdgUaXmNUHJ8zGwAtvOMuXXHqoJpsCyU_aPLbGNP7o0kTjE75DVoiAbHQ=\\\",\\\"description\\\":\\\"Prove that the \\\\\\\"identifier\\\\\\\" is the identifier hidden in attestation contained in\\\\\\\"payload\\\\\\\" and use this to authorize usage of local, temporary keys.\\\",\\\"timestamp\\\":\\\"Thu Aug 5 2021 08:17:29 GMT+0000\\\",\\\"identifier\\\":\\\"email@test.com\\\",\\\"expirationTime\\\":\\\"Sat Aug 5 10051 07:17:28 GMT+0000\\\"},\\\"domain\\\":{\\\"name\\\":\\\"https://www.attestation.id\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
+  void writeTestMaterial() throws Exception {
+    Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
+            requestWithUsage, userSigningKey);
+    FileImportExport.storeToken(request.getJsonEncoding(), "eip712-att-req-usage");
+
+    // Validate loading
+    String decodedToken = FileImportExport.loadToken("eip712-att-req-usage");
+    Eip712AttestationRequestWithUsage req = new Eip712AttestationRequestWithUsage(DOMAIN, decodedToken);
+    assertTrue(req.checkValidity());
+    assertTrue(req.checkTokenValidity());
+    assertTrue(req.verify());
+  }
+
+  @Test
+  void referenceJsonFormat() {
+    String request = "{\"signatureInHex\":\"0x81dcaa2cacd85a2cb731660778cfef76b0261423476d03b215638351cc14882b5dc29ef45402c61872cf63b54c30788041e7624c440b002780d569fc4fd1dd8e1b\",\"jsonSigned\":\"{\\\"types\\\":{\\\"AttestationRequestWUsage\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"expirationTime\\\",\\\"type\\\":\\\"string\\\"}],\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequestWUsage\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIICTQIBATCB_ARBBB62SP-dgZtAemxY0nl4cjxOW0UKyYmDPOz2_YfDFgzeCa3ZVleOniCjeTfuoR9NTatdcoM4IruwzSUv-DniQbcEICIO6_fhc4D0RJEKC1yB3LGvEoXAatK60lC-ipFW-Y26BEEEDFVwBw77_sz-3PcHsmrwCbfzlcYJpvrh1dcYJCcxAAQlgxlEE72jadyvtgoUs-ttKmV-pQN0FXiBiBgU0q9vswRSMFg1RjdCRkU3NTJBQzFBNDVGNjc0OTdEOURDREQ5QkJEQTUwQTgzOTU1Sm1UC7EZ7FbQ1gD2qvRqimx8roUC_TlKlL_iMtn-uNsAAAF7FWOBwDCCAUcwgfgGByqGSM49AgEwgewCAQEwJQYHKoZIzj0BAjAaAgIBGwYJKoZIzj0BAgMDMAkCAQUCAQcCAQwwTAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEESQQFAyE_eMpEiD8aO4Fi8YjlU80mXyPBVnoWh2kTsMKsJFhJKDYBzNo4DxyeMY2Q-V0H5UJv6H5FwOgYRpjkWWI2TjQRYXfdIlkCJAH______________________-muLtB1dyZd_3-URR4GHhY8YQIBBANKAAQFK7J9i33xUcv3NBo2Xh82NNDkiqCBaefEwx4sRgxdgUaXmNUHJ8zGwAtvOMuXXHqoJpsCyU_aPLbGNP7o0kTjE75DVoiAbHQ=\\\",\\\"description\\\":\\\"Prove that the \\\\\\\"identifier\\\\\\\" is the identifier hidden in attestation contained in\\\\\\\"payload\\\\\\\" and use this to authorize usage of local, temporary keys.\\\",\\\"timestamp\\\":\\\"Thu Aug 5 2021 08:17:29 GMT+0000\\\",\\\"identifier\\\":\\\"email@test.com\\\",\\\"expirationTime\\\":\\\"Sat Aug 5 10051 07:17:28 GMT+0000\\\"},\\\"domain\\\":{\\\"name\\\":\\\"https://www.attestation.id\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
     Eip712AttestationRequestWithUsage eiprequest =
-        new Eip712AttestationRequestWithUsage(DOMAIN, Timestamp.UNLIMITED, Timestamp.UNLIMITED, request);
+            new Eip712AttestationRequestWithUsage(DOMAIN, Timestamp.UNLIMITED, Timestamp.UNLIMITED, request);
     assertTrue(eiprequest.verify());
     assertTrue(eiprequest.checkValidity());
     assertTrue(eiprequest.checkTokenValidity());
     Eip712AttestationRequestWithUsage lessValidRequest =
-        new Eip712AttestationRequestWithUsage(DOMAIN, 1000L*10L, Timestamp.UNLIMITED, request);
+            new Eip712AttestationRequestWithUsage(DOMAIN, 1000L * 10L, Timestamp.UNLIMITED, request);
     assertTrue(lessValidRequest.verify());
     assertFalse(lessValidRequest.checkValidity());
     assertTrue(lessValidRequest.checkTokenValidity());
@@ -93,17 +106,17 @@ public class TestAttestationRequestWithUsageEip712 {
   }
 
   @Test
-  public void testSunshine() {
+  void testSunshine() {
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        requestWithUsage, userSigningKey);
+            requestWithUsage, userSigningKey);
     assertTrue(request.verify());
     assertTrue(request.checkValidity());
     assertTrue(request.checkTokenValidity());
   }
 
   @Test
-  public void otherTimeLimit() throws Exception {
-    Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN,  1000L*60L, Timestamp.UNLIMITED, MAIL, requestWithUsage, userSigningKey);
+  void otherTimeLimit() {
+    Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, 1000L * 60L, Timestamp.UNLIMITED, MAIL, requestWithUsage, userSigningKey);
     assertTrue(request.verify());
     assertTrue(request.checkValidity());
     assertTrue(request.checkTokenValidity());
@@ -111,9 +124,9 @@ public class TestAttestationRequestWithUsageEip712 {
 
 
   @Test
-  public void testDecoding() throws Exception {
+  void testDecoding() throws Exception {
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        requestWithUsage, userSigningKey);
+            requestWithUsage, userSigningKey);
     Eip712AttestationRequestWithUsage newRequest = new Eip712AttestationRequestWithUsage(DOMAIN, request.getJsonEncoding());
     assertTrue(newRequest.verify());
     assertTrue(newRequest.checkValidity());
@@ -132,71 +145,71 @@ public class TestAttestationRequestWithUsageEip712 {
   }
 
   @Test
-  public void eipEncoding() throws Exception {
+  void eipEncoding() throws Exception {
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        requestWithUsage, userSigningKey);
+            requestWithUsage, userSigningKey);
     Eip712Test.validateEncoding(encoder, request.getJsonEncoding());
   }
 
   @Test
-  public void eipSignableEncoding() throws Exception {
+  void eipSignableEncoding() throws Exception {
     Timestamp now = new Timestamp();
     Timestamp expirationTime = new Timestamp(now.getTime() + 1000);
     AttestationRequestWUsageData data = new AttestationRequestWUsageData(
-        encoder.getUsageValue(), MAIL, URLUtility.encodeData(requestWithUsage.getDerEncoding()), now, expirationTime);
-    Eip712Signer issuer = new Eip712Signer<AttestationRequestWUsageData>(userSigningKey, encoder);
+            encoder.getUsageValue(), MAIL, URLUtility.encodeData(requestWithUsage.getDerEncoding()), now, expirationTime);
+    Eip712Signer<AttestationRequestWUsageData> issuer = new Eip712Signer<>(userSigningKey, encoder);
     String json = issuer.buildSignedTokenFromJsonObject(data.getSignableVersion(), DOMAIN);
     Eip712Test.validateEncoding(encoder, json);
   }
 
   @Test
-  public void badSignature() {
+  void badSignature() {
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        requestWithUsage, userSigningKey);
+            requestWithUsage, userSigningKey);
     byte[] encoding = request.getJsonEncoding().getBytes(StandardCharsets.UTF_8);
     // Flip a bit in the signature part of the encoding
     encoding[40] ^= 0x01;
     assertThrows(IllegalArgumentException.class,
-        () -> new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(), new String(encoding)));
+            () -> new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(), new String(encoding)));
   }
 
   @Test
-  public void expiredToken() throws Exception {
-    Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, Timestamp.DEFAULT_TIME_LIMIT_MS, -Timestamp.ALLOWED_ROUNDING*2,
-        MAIL, requestWithUsage, userSigningKey);
+  void expiredToken() {
+    Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, Timestamp.DEFAULT_TIME_LIMIT_MS, -Timestamp.ALLOWED_ROUNDING * 2,
+            MAIL, requestWithUsage, userSigningKey);
     assertTrue(request.verify());
     assertTrue(request.checkValidity());
     assertFalse(request.checkTokenValidity());
   }
 
   @Test
-  public void invalidTimestamp() {
-    Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, -Timestamp.ALLOWED_ROUNDING*2,
-        Timestamp.DEFAULT_TOKEN_TIME_LIMIT, MAIL, requestWithUsage, userSigningKey);
+  void invalidTimestamp() {
+    Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, -Timestamp.ALLOWED_ROUNDING * 2,
+            Timestamp.DEFAULT_TOKEN_TIME_LIMIT, MAIL, requestWithUsage, userSigningKey);
     assertTrue(request.verify());
     assertFalse(request.checkValidity());
     assertTrue(request.checkTokenValidity());
   }
 
   @Test
-  public void invalidNonceDomain() {
+  void invalidNonceDomain() {
     byte[] wrongNonce = Nonce.makeNonce(userAddress, "http://www.notCorrect.com", new Timestamp());
     FullProofOfExponent wrongPok = crypto.computeAttestationProof(ATTESTATION_SECRET, wrongNonce);
     AttestationRequestWithUsage usage = new AttestationRequestWithUsage(TYPE, wrongPok, sessionKey);
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        usage, userSigningKey);
+            usage, userSigningKey);
     assertTrue(request.verify());
     assertFalse(request.checkValidity());
     assertFalse(request.checkTokenValidity());
   }
 
   @Test
-  public void invalidNonce() {
-    byte[] wrongNonce = new byte[] {0x01, 0x02, 0x03};
+  void invalidNonce() {
+    byte[] wrongNonce = new byte[]{0x01, 0x02, 0x03};
     FullProofOfExponent wrongPok = crypto.computeAttestationProof(ATTESTATION_SECRET, wrongNonce);
     AttestationRequestWithUsage usage = new AttestationRequestWithUsage(TYPE, wrongPok, sessionKey);
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        usage, userSigningKey);
+            usage, userSigningKey);
     assertTrue(request.verify());
     assertFalse(request.checkValidity());
     assertFalse(request.checkTokenValidity());
@@ -204,44 +217,45 @@ public class TestAttestationRequestWithUsageEip712 {
 
   @Mock
   AttestationRequestWithUsage mockedAttReqUsage;
+
   @Test
-  public void nonVerifiableUseAttestation() {
+  void nonVerifiableUseAttestation() {
     // First verification is done in the constructor of Eip712AttestationUsage
     Mockito.when(mockedAttReqUsage.verify()).thenReturn(true).thenReturn(false);
-    Mockito.when(mockedAttReqUsage.getDerEncoding()).thenReturn(new byte[] {0x00});
+    Mockito.when(mockedAttReqUsage.getDerEncoding()).thenReturn(new byte[]{0x00});
     Mockito.when(mockedAttReqUsage.getPok()).thenReturn(pok);
     Mockito.when(mockedAttReqUsage.getType()).thenReturn(TYPE);
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        mockedAttReqUsage, userSigningKey);
+            mockedAttReqUsage, userSigningKey);
     assertFalse(request.verify());
     assertTrue(request.checkValidity());
     assertTrue(request.checkTokenValidity());
   }
 
   @Test
-  public void invalidConstructor() {
+  void invalidConstructor() {
     Mockito.when(mockedAttReqUsage.verify()).thenReturn(true);
     Mockito.when(mockedAttReqUsage.getDerEncoding()).thenReturn(null);
     // Wrong signing keys
-    Exception e = assertThrows( IllegalArgumentException.class, () ->  new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        mockedAttReqUsage,
-        userSigningKey));
+    Exception e = assertThrows(IllegalArgumentException.class, () -> new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
+            mockedAttReqUsage,
+            userSigningKey));
     assertEquals("Could not encode object", e.getMessage());
   }
 
   @Test
-  public void invalidOtherConstructor() {
+  void invalidOtherConstructor() {
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, MAIL,
-        requestWithUsage,
-        userSigningKey);
+            requestWithUsage,
+            userSigningKey);
     String json = request.getJsonEncoding();
     String wrongJson = json.replace(',', '.');
-    Exception e = assertThrows( IllegalArgumentException.class, () ->  new Eip712AttestationRequestWithUsage(DOMAIN, wrongJson));
+    Exception e = assertThrows(IllegalArgumentException.class, () -> new Eip712AttestationRequestWithUsage(DOMAIN, wrongJson));
     assertEquals("Could not decode object", e.getMessage());
   }
 
   @Test
-  public void wrongSignature() throws Exception {
+  void wrongSignature() {
     String jsonInvalidSig = "{\"signatureInHex\":\"0x5492e356581bf3a249d55245f25f52f25088434660aad9c37b6e86a7224a86877e6f472786c0dbb6f24268b0ea4891288b42be18e571a04ec2599f48714b28641c\",\"jsonSigned\":\"{\\\"types\\\":{\\\"AttestationRequestWUsage\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"expirationTime\\\",\\\"type\\\":\\\"string\\\"}],\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequestWUsage\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIICTQIBATCB_ARBBB62SP-dgZtAemxY0nl4cjxOW0UKyYmDPOz2_YfDFgzeCa3ZVleOniCjeTfuoR9NTatdcoM4IruwzSUv-DniQbcEICBJ1TB0lMnjO3E4mRpuqh1hdjjYGc4RhOgHtA9PsD4iBEEEA2ka_nOn_7cfWROcSuXtb_BBX8bc7N8yi47FwS1_63oLadplUtvj7U0wrPVNmlzCZ98EqoEKXNZLGOmMpspqaARSMFg1RjdCRkU3NTJBQzFBNDVGNjc0OTdEOURDREQ5QkJEQTUwQTgzOTU1Sm1UC7EZ7FbQ1gD2qvRqimx8roUC_TlKlL_iMtn-uNsAAAGA4a6SYDCCAUcwgfgGByqGSM49AgEwgewCAQEwJQYHKoZIzj0BAjAaAgIBGwYJKoZIzj0BAgMDMAkCAQUCAQcCAQwwTAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEESQQFAyE_eMpEiD8aO4Fi8YjlU80mXyPBVnoWh2kTsMKsJFhJKDYBzNo4DxyeMY2Q-V0H5UJv6H5FwOgYRpjkWWI2TjQRYXfdIlkCJAH______________________-muLtB1dyZd_3-URR4GHhY8YQIBBANKAAQFK7J9i33xUcv3NBo2Xh82NNDkiqCBaefEwx4sRgxdgUaXmNUHJ8zGwAtvOMuXXHqoJpsCyU_aPLbGNP7o0kTjE75DVoiAbHQ=\\\",\\\"description\\\":\\\"Prove that the \\\\\\\"identifier\\\\\\\" is the identifier hidden in attestation contained in\\\\\\\"payload\\\\\\\" and use this to authorize usage of local, temporary keys.\\\",\\\"timestamp\\\":\\\"Fri May 20 2022 13:35:56 GMT+0000\\\",\\\"identifier\\\":\\\"email@test.com\\\",\\\"expirationTime\\\":\\\"Sat May 20 2023 13:35:56 GMT+0000\\\"},\\\"domain\\\":{\\\"name\\\":\\\"https://www.attestation.id\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, Timestamp.UNLIMITED, Timestamp.UNLIMITED, jsonInvalidSig);
     assertTrue(request.verify());
@@ -251,7 +265,7 @@ public class TestAttestationRequestWithUsageEip712 {
   }
 
   @Test
-  public void checkKeyRecovery() {
+  void checkKeyRecovery() {
     // Request with modified signature but signed with "userSigningKey"
     String jsonInvalidSig = "{\"signatureInHex\":\"0x5492e356581bf3a249d55245f25f52f25088434660aad9c37b6e86a7224a86877e6f472786c0dbb6f24268b0ea4891288b42be18e571a04ec2599f48714b28641c\",\"jsonSigned\":\"{\\\"types\\\":{\\\"AttestationRequestWUsage\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"expirationTime\\\",\\\"type\\\":\\\"string\\\"}],\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"}]},\\\"primaryType\\\":\\\"AttestationRequestWUsage\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIICTQIBATCB_ARBBB62SP-dgZtAemxY0nl4cjxOW0UKyYmDPOz2_YfDFgzeCa3ZVleOniCjeTfuoR9NTatdcoM4IruwzSUv-DniQbcEICBJ1TB0lMnjO3E4mRpuqh1hdjjYGc4RhOgHtA9PsD4iBEEEA2ka_nOn_7cfWROcSuXtb_BBX8bc7N8yi47FwS1_63oLadplUtvj7U0wrPVNmlzCZ98EqoEKXNZLGOmMpspqaARSMFg1RjdCRkU3NTJBQzFBNDVGNjc0OTdEOURDREQ5QkJEQTUwQTgzOTU1Sm1UC7EZ7FbQ1gD2qvRqimx8roUC_TlKlL_iMtn-uNsAAAGA4a6SYDCCAUcwgfgGByqGSM49AgEwgewCAQEwJQYHKoZIzj0BAjAaAgIBGwYJKoZIzj0BAgMDMAkCAQUCAQcCAQwwTAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEESQQFAyE_eMpEiD8aO4Fi8YjlU80mXyPBVnoWh2kTsMKsJFhJKDYBzNo4DxyeMY2Q-V0H5UJv6H5FwOgYRpjkWWI2TjQRYXfdIlkCJAH______________________-muLtB1dyZd_3-URR4GHhY8YQIBBANKAAQFK7J9i33xUcv3NBo2Xh82NNDkiqCBaefEwx4sRgxdgUaXmNUHJ8zGwAtvOMuXXHqoJpsCyU_aPLbGNP7o0kTjE75DVoiAbHQ=\\\",\\\"description\\\":\\\"Prove that the \\\\\\\"identifier\\\\\\\" is the identifier hidden in attestation contained in\\\\\\\"payload\\\\\\\" and use this to authorize usage of local, temporary keys.\\\",\\\"timestamp\\\":\\\"Fri May 20 2022 13:35:56 GMT+0000\\\",\\\"identifier\\\":\\\"email@test.com\\\",\\\"expirationTime\\\":\\\"Sat May 20 2023 13:35:56 GMT+0000\\\"},\\\"domain\\\":{\\\"name\\\":\\\"https://www.attestation.id\\\",\\\"version\\\":\\\"0.1\\\"}}\"}";
     Eip712AttestationRequestWithUsage request = new Eip712AttestationRequestWithUsage(DOMAIN, Timestamp.UNLIMITED, Timestamp.UNLIMITED, jsonInvalidSig);
@@ -260,7 +274,7 @@ public class TestAttestationRequestWithUsageEip712 {
   }
 
   @Test
-  public void validateWrongNonceKey() {
+  void validateWrongNonceKey() {
     // Notice the wrong address
     byte[] nonce = Nonce.makeNonce("0x1234567890123456789012345678901234567890", DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);

--- a/src/test/java/org/tokenscript/attestation/eip712/TestAttestationUsageEip712.java
+++ b/src/test/java/org/tokenscript/attestation/eip712/TestAttestationUsageEip712.java
@@ -1,13 +1,5 @@
 package org.tokenscript.attestation.eip712;
 
-import org.tokenscript.attestation.*;
-import org.tokenscript.attestation.IdentifierAttestation.AttestationType;
-import org.tokenscript.attestation.core.AttestationCrypto;
-import org.tokenscript.attestation.core.SignatureUtility;
-import org.tokenscript.attestation.core.URLUtility;
-import org.tokenscript.attestation.eip712.Eip712AttestationUsageEncoder.AttestationUsageData;
-import java.math.BigInteger;
-import java.security.SecureRandom;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
@@ -20,8 +12,17 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.tokenscript.attestation.*;
+import org.tokenscript.attestation.IdentifierAttestation.AttestationType;
+import org.tokenscript.attestation.core.AttestationCrypto;
+import org.tokenscript.attestation.core.SignatureUtility;
+import org.tokenscript.attestation.core.URLUtility;
+import org.tokenscript.attestation.eip712.Eip712AttestationUsageEncoder.AttestationUsageData;
 import org.tokenscript.eip712.Eip712Signer;
 import org.tokenscript.eip712.Eip712Test;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -65,20 +66,36 @@ public class TestAttestationUsageEip712 {
 
   @BeforeEach
   public void init() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test
-  public void referenceJsonFormat() {
+  void writeTestMaterial() throws Exception {
+    FileImportExport.storeKey(attestorKeys.getPublic(), "eip712-att-req-usage-key");
+    UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
+    Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, MAIL,
+            usage, userSigningKey);
+    FileImportExport.storeToken(request.getJsonEncoding(), "eip712-att-req-usage");
+
+    // Validate loading
+    AsymmetricKeyParameter eip712TicketKey = FileImportExport.loadKey("eip712-att-req-usage-key");
+    String decodedToken = FileImportExport.loadToken("eip712-att-req-usage");
+    Eip712AttestationUsage req = new Eip712AttestationUsage(DOMAIN, eip712TicketKey, decodedToken);
+    assertTrue(req.checkTokenValidity());
+    assertTrue(req.verify());
+  }
+
+  @Test
+  void referenceJsonFormat() {
     String request = "{\"signatureInHex\":\"0x2396cde0c922693ad14a8496b4ad8418edd55c0d22b134e9823edbede910f3114ef885039d011662f4f7ce607b1985c0f97c32522cb78d8ad47aea4c09a398231b\",\"jsonSigned\":\"{\\\"types\\\":{\\\"AttestationUsage\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"expirationTime\\\",\\\"type\\\":\\\"string\\\"}],\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"chainId\\\",\\\"type\\\":\\\"uint256\\\"}]},\\\"primaryType\\\":\\\"AttestationUsage\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIIEnTCCAkwwggH5oAMCARICAQEwCQYHKoZIzj0EAjAOMQwwCgYDVQQDDANBTFgwLhgPMjAyMjAzMjQxMjE4MThaAgRiPGGKGA8yMDMyMDMyMTEyMTgxOFoCBHUIZIowCzEJMAcGA1UEAwwAMIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA_____________________________________v___C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5hIOtp3JqPEZV2k-_wOEQio_Re0SKaFVBmcR9CP-xDUuAIhAP____________________66rtzmr0igO7_SXozQNkFBAgEBA0IABNNj3-rhhwxBABhmJpTmPZzkcJ6mElV8GFTdL8aGGsseXxiO8jZNWjDMFSqKAPOHT8sVZV66_uNVTxKQgDgZ8_EwBwIBKgICBTmjVzBVMFMGCysGAQQBizpzeQEoAQH_BEEEBf4waGibxLr-xOtIPTqSyPUm7VhND0Wemc6TpRIpCgQVYa-Hh9BK_SkBIguxAbZb1l_SGiHV9mTj-uzDq4UDCTAJBgcqhkjOPQQCA0IAEDlbV7apQ916acvzZjx-loOTGfLAHrq_ZoLrCJTuWlgjOzsbBLgsK5UUXjqjWxOtOLLBOQhTNF7ewvRLqd8hPxsCAQEwgfwEQQQetkj_nYGbQHpsWNJ5eHI8TltFCsmJgzzs9v2HwxYM3gmt2VZXjp4go3k37qEfTU2rXXKDOCK7sM0lL_g54kG3BCAqodsH2iDEWdpI3WUN3xZhzoVHblgd-knV_-3xLIWRGQRBBArui58APwMxF83AK3AuCNBAnE500oxmxhdfs8GjA2kXIF-K6ji3fpzTtpqHDd2AMcrosNJ1BAR2tpR2Ip2FukEEUjBYNUY3QkZFNzUyQUMxQTQ1RjY3NDk3RDlEQ0REOUJCREE1MEE4Mzk1NcBxJpS6VWwViG_3TFMX3w_C5Rk1h9lTxNkbTSZP6dyrAAABf7vdAxAwggFHMIH4BgcqhkjOPQIBMIHsAgEBMCUGByqGSM49AQIwGgICARsGCSqGSM49AQIDAzAJAgEFAgEHAgEMMEwEJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBEkEBQMhP3jKRIg_GjuBYvGI5VPNJl8jwVZ6FodpE7DCrCRYSSg2AczaOA8cnjGNkPldB-VCb-h-RcDoGEaY5FliNk40EWF33SJZAiQB_______________________pri7QdXcmXf9_lEUeBh4WPGECAQQDSgAEAU0LBiRPJvqOUJ-vR0YpncGsvKo_b9CHvpRg00x5BNDEt6UKAZugFiCZLf7_nT12DRsph7PE9PvwTIbUQt8S7We1E-MCkMjH\\\",\\\"description\\\":\\\"Prove that the \\\\\\\"identifier\\\\\\\" is the identifier hidden in attestation contained in\\\\\\\"payload\\\\\\\".\\\",\\\"timestamp\\\":\\\"Thu Mar 24 2022 12:18:26 GMT+0000\\\",\\\"identifier\\\":\\\"email@test.com\\\",\\\"expirationTime\\\":\\\"Sat Mar 23 10052 11:18:25 GMT+0000\\\"},\\\"domain\\\":{\\\"name\\\":\\\"https://www.hotelbogota.com\\\",\\\"version\\\":\\\"0.1\\\",\\\"chainId\\\":42}}\"}";
     Eip712AttestationUsage eiprequest = new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(),
-        Timestamp.UNLIMITED, 42, request);
+            Timestamp.UNLIMITED, 42, request);
     assertTrue(eiprequest.verify());
     assertTrue(eiprequest.checkTokenValidity());
   }
 
   @Test
-  public void testSunshine() {
+  void testSunshine() {
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
     assertTrue(usage.verify());
     assertTrue(usage.checkValidity());
@@ -88,17 +105,17 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void otherTimeLimit() {
+  void otherTimeLimit() {
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
     assertTrue(usage.verify());
     assertTrue(usage.checkValidity());
-    Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN,  Timestamp.UNLIMITED, 42, MAIL, usage, userSigningKey);
+    Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, Timestamp.UNLIMITED, 42, MAIL, usage, userSigningKey);
     assertTrue(request.verify());
     assertTrue(request.checkTokenValidity());
   }
 
   @Test
-  public void testDecoding() throws Exception {
+  void testDecoding() throws Exception {
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, MAIL, usage, userSigningKey);
     Eip712AttestationUsage newRequest = new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(), request.getJsonEncoding());
@@ -120,27 +137,27 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void eipEncoding() throws Exception {
+  void eipEncoding() throws Exception {
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, MAIL, usage, userSigningKey);
     Eip712Test.validateEncoding(encoder, request.getJsonEncoding());
   }
 
   @Test
-  public void eipSignableEncoding() throws Exception {
+  void eipSignableEncoding() throws Exception {
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
     Timestamp now = new Timestamp();
     Timestamp expirationTime = new Timestamp(now.getTime() + 1000);
     AttestationUsageData data = new AttestationUsageData(
-        encoder.getUsageValue(),
-        MAIL, URLUtility.encodeData(usage.getDerEncoding()), now, expirationTime);
-    Eip712Signer issuer = new Eip712Signer<AttestationUsageData>(userSigningKey, encoder);
+            encoder.getUsageValue(),
+            MAIL, URLUtility.encodeData(usage.getDerEncoding()), now, expirationTime);
+    Eip712Signer<AttestationUsageData> issuer = new Eip712Signer<>(userSigningKey, encoder);
     String json = issuer.buildSignedTokenFromJsonObject(data.getSignableVersion(), DOMAIN);
     Eip712Test.validateEncoding(encoder, json);
   }
 
   @Test
-  public void badAttesattion() {
+  void badAttesattion() {
     Mockito.when(mockedUseAttestation.getDerEncoding()).thenReturn(new byte[0]);
     Mockito.when(mockedUseAttestation.verify()).thenReturn(false);
     Exception e = assertThrows(IllegalArgumentException.class, () -> new Eip712AttestationUsage(DOMAIN, MAIL, mockedUseAttestation, userSigningKey));
@@ -148,16 +165,16 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void expiredToken() throws Exception {
+  void expiredToken() {
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
-    Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, -Timestamp.ALLOWED_ROUNDING*2, CHAIN_ID,
-        MAIL, usage, userSigningKey);
+    Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, -Timestamp.ALLOWED_ROUNDING * 2, CHAIN_ID,
+            MAIL, usage, userSigningKey);
     assertTrue(request.verify());
     assertFalse(request.checkTokenValidity());
   }
 
   @Test
-  public void invalidNonceDomain() {
+  void invalidNonceDomain() {
     byte[] wrongNonce = Nonce.makeNonce(userAddress, "http://www.notTheRightHotel.com", new Timestamp());
     FullProofOfExponent wrongPok = crypto.computeAttestationProof(ATTESTATION_SECRET, wrongNonce);
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, wrongPok, sessionKey);
@@ -167,8 +184,8 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void invalidNonceAddress() {
-    byte[] wrongNonce = new byte[] {0x01, 0x02, 0x03};
+  void invalidNonceAddress() {
+    byte[] wrongNonce = new byte[]{0x01, 0x02, 0x03};
     FullProofOfExponent wrongPok = crypto.computeAttestationProof(ATTESTATION_SECRET, wrongNonce);
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, wrongPok, sessionKey);
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, MAIL, usage, userSigningKey);
@@ -177,7 +194,7 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void invalidNonceBadIdentifier() {
+  void invalidNonceBadIdentifier() {
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, "notTheRight@email.com", usage, userSigningKey);
     assertTrue(request.verify());
@@ -186,10 +203,11 @@ public class TestAttestationUsageEip712 {
 
   @Mock
   UseAttestation mockedUseAttestation;
+
   @Test
-  public void invalidUseAttestation() {
+  void invalidUseAttestation() {
     Mockito.when(mockedUseAttestation.verify()).thenReturn(true);
-    Mockito.when(mockedUseAttestation.getDerEncoding()).thenReturn(new byte[] {0x00});
+    Mockito.when(mockedUseAttestation.getDerEncoding()).thenReturn(new byte[]{0x00});
     Mockito.when(mockedUseAttestation.getAttestation()).thenReturn(signedAttestation);
     Mockito.when(mockedUseAttestation.getPok()).thenReturn(pok);
     Mockito.when(mockedUseAttestation.getType()).thenReturn(TYPE);
@@ -200,10 +218,10 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void nonverifiableUseAttesation() {
+  void nonverifiableUseAttesation() {
     // First verification is done in the constructor of Eip712AttestationUsage
     Mockito.when(mockedUseAttestation.verify()).thenReturn(true).thenReturn(false);
-    Mockito.when(mockedUseAttestation.getDerEncoding()).thenReturn(new byte[] {0x00});
+    Mockito.when(mockedUseAttestation.getDerEncoding()).thenReturn(new byte[]{0x00});
     Mockito.when(mockedUseAttestation.getAttestation()).thenReturn(signedAttestation);
     Mockito.when(mockedUseAttestation.getPok()).thenReturn(pok);
     Mockito.when(mockedUseAttestation.getType()).thenReturn(TYPE);
@@ -214,7 +232,7 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void invalidProofLinking() {
+  void invalidProofLinking() {
     // Wrong type
     UseAttestation usage = new UseAttestation(signedAttestation, AttestationType.PHONE, pok, sessionKey);
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, MAIL, usage, userSigningKey);
@@ -223,10 +241,10 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void badAddressInNonce() {
+  void badAddressInNonce() {
     AsymmetricCipherKeyPair otherUserKeys = SignatureUtility.constructECKeysWithSmallestY(rand);
     IdentifierAttestation att = HelperTest
-        .makeUnsignedStandardAtt(otherUserKeys.getPublic(), attestorKeys.getPublic(), ATTESTATION_SECRET, MAIL);
+            .makeUnsignedStandardAtt(otherUserKeys.getPublic(), attestorKeys.getPublic(), ATTESTATION_SECRET, MAIL);
     SignedIdentifierAttestation otherSingedAttestation = new SignedIdentifierAttestation(att, attestorKeys);
     UseAttestation usage = new UseAttestation(otherSingedAttestation, TYPE, pok, sessionKey);
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, MAIL, usage, userSigningKey);
@@ -234,29 +252,29 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void invalidConstructor() {
+  void invalidConstructor() {
     Mockito.when(mockedUseAttestation.verify()).thenReturn(true);
     Mockito.when(mockedUseAttestation.getDerEncoding()).thenReturn(null);
     // Wrong signing keys
-    Exception e = assertThrows( IllegalArgumentException.class, () ->  new Eip712AttestationUsage(DOMAIN, MAIL, mockedUseAttestation,
-        userSigningKey));
+    Exception e = assertThrows(IllegalArgumentException.class, () -> new Eip712AttestationUsage(DOMAIN, MAIL, mockedUseAttestation,
+            userSigningKey));
     assertEquals("Could not encode asn1", e.getMessage());
   }
 
   @Test
-  public void invalidOtherConstructor() {
+  void invalidOtherConstructor() {
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);
     UseAttestation usage = new UseAttestation(signedAttestation, TYPE, pok, sessionKey);
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, MAIL, usage, userSigningKey);
     String json = request.getJsonEncoding();
     String wrongJson = json.replace(',', '.');
-    Exception e = assertThrows( IllegalArgumentException.class, () ->  new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(), wrongJson));
+    Exception e = assertThrows(IllegalArgumentException.class, () -> new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(), wrongJson));
     assertEquals("Could not decode asn1", e.getMessage());
   }
 
 
   @Test
-  public void wrongSignature() throws Exception {
+  void wrongSignature() {
     String jsonInvalidSig = "{\"signatureInHex\":\"0xe46f9fb4a4df834b2b83cc75817919af9a69ee0350bd4bb1a421080d5974424800f66b55700e3be26103c2ee89fd646bcb0d721656d2e18e2de78881e7a611e61c\",\"jsonSigned\":\"{\\\"types\\\":{\\\"AttestationUsage\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"expirationTime\\\",\\\"type\\\":\\\"string\\\"}],\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"chainId\\\",\\\"type\\\":\\\"uint256\\\"}]},\\\"primaryType\\\":\\\"AttestationUsage\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIIEnTCCAkwwggH5oAMCARICAQEwCQYHKoZIzj0EAjAOMQwwCgYDVQQDDANBTFgwLhgPMjAyMjA1MjAxMzQyMjhaAgRih5rEGA8yMDMyMDUxNzEzNDI0M1oCBHVTndMwCzEJMAcGA1UEAwwAMIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA_____________________________________v___C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5hIOtp3JqPEZV2k-_wOEQio_Re0SKaFVBmcR9CP-xDUuAIhAP____________________66rtzmr0igO7_SXozQNkFBAgEBA0IABNNj3-rhhwxBABhmJpTmPZzkcJ6mElV8GFTdL8aGGsseXxiO8jZNWjDMFSqKAPOHT8sVZV66_uNVTxKQgDgZ8_EwBwIBKgICBTmjVzBVMFMGCysGAQQBizpzeQEoAQH_BEEEBf4waGibxLr-xOtIPTqSyPUm7VhND0Wemc6TpRIpCgQVYa-Hh9BK_SkBIguxAbZb1l_SGiHV9mTj-uzDq4UDCTAJBgcqhkjOPQQCA0IAwzeiNwHfnk9f9Npkh9_iWLl6DV8VIdqCc_Dud-yygJ0Qlt_rRzooGOfmi3uaeBwLO5hPOCkbRPVKJo989qd7hBsCAQEwgfwEQQQetkj_nYGbQHpsWNJ5eHI8TltFCsmJgzzs9v2HwxYM3gmt2VZXjp4go3k37qEfTU2rXXKDOCK7sM0lL_g54kG3BCAoyU3VhYrmjwVHG9q6GJc9HM88VSjvfKl5L2gGR8sXaARBBCuONwsSB9Elx41TAs_HPLwWHh3xXgxfrzgjy1qpzdiUBiv-iUljSzooGoQBeMBczcmtts1rujewpgQ4U9-i5V8EUjBYNUY3QkZFNzUyQUMxQTQ1RjY3NDk3RDlEQ0REOUJCREE1MEE4Mzk1NcBxJpS6VWwViG_3TFMX3w_C5Rk1h9lTxNkbTSZP6dyrAAABgOG0yDgwggFHMIH4BgcqhkjOPQIBMIHsAgEBMCUGByqGSM49AQIwGgICARsGCSqGSM49AQIDAzAJAgEFAgEHAgEMMEwEJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBEkEBQMhP3jKRIg_GjuBYvGI5VPNJl8jwVZ6FodpE7DCrCRYSSg2AczaOA8cnjGNkPldB-VCb-h-RcDoGEaY5FliNk40EWF33SJZAiQB_______________________pri7QdXcmXf9_lEUeBh4WPGECAQQDSgAEByc72m2s0_jBop-62ySxOmAR5gw32JVHF50_cmbjxnFYwHEsAUMY0LO578TX5xO7FMuir1CEu8V1tiq1TpyIOVz-M_xl84Hr\\\",\\\"description\\\":\\\"Prove that the \\\\\\\"identifier\\\\\\\" is the identifier hidden in attestation contained in\\\\\\\"payload\\\\\\\".\\\",\\\"timestamp\\\":\\\"Fri May 20 2022 13:42:44 GMT+0000\\\",\\\"identifier\\\":\\\"email@test.com\\\",\\\"expirationTime\\\":\\\"Sat May 20 2023 13:42:44 GMT+0000\\\"},\\\"domain\\\":{\\\"name\\\":\\\"https://www.hotelbogota.com\\\",\\\"version\\\":\\\"0.1\\\",\\\"chainId\\\":0}}\"}";
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(), Timestamp.UNLIMITED, 0, jsonInvalidSig);
     assertTrue(request.verify());
@@ -265,16 +283,16 @@ public class TestAttestationUsageEip712 {
   }
 
   @Test
-  public void checkKeyRecovery() {
+  void checkKeyRecovery() {
     // Request with modified signature but signed with "userSigningKey"
     String jsonInvalidSig = "{\"signatureInHex\":\"0xe46f9fb4a4df834b2b83cc75817919af9a69ee0350bd4bb1a421080d5974424800f66b55700e3be26103c2ee89fd646bcb0d721656d2e18e2de78881e7a611e61c\",\"jsonSigned\":\"{\\\"types\\\":{\\\"AttestationUsage\\\":[{\\\"name\\\":\\\"payload\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"description\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"timestamp\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"identifier\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"expirationTime\\\",\\\"type\\\":\\\"string\\\"}],\\\"EIP712Domain\\\":[{\\\"name\\\":\\\"name\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"version\\\",\\\"type\\\":\\\"string\\\"},{\\\"name\\\":\\\"chainId\\\",\\\"type\\\":\\\"uint256\\\"}]},\\\"primaryType\\\":\\\"AttestationUsage\\\",\\\"message\\\":{\\\"payload\\\":\\\"MIIEnTCCAkwwggH5oAMCARICAQEwCQYHKoZIzj0EAjAOMQwwCgYDVQQDDANBTFgwLhgPMjAyMjA1MjAxMzQyMjhaAgRih5rEGA8yMDMyMDUxNzEzNDI0M1oCBHVTndMwCzEJMAcGA1UEAwwAMIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA_____________________________________v___C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5hIOtp3JqPEZV2k-_wOEQio_Re0SKaFVBmcR9CP-xDUuAIhAP____________________66rtzmr0igO7_SXozQNkFBAgEBA0IABNNj3-rhhwxBABhmJpTmPZzkcJ6mElV8GFTdL8aGGsseXxiO8jZNWjDMFSqKAPOHT8sVZV66_uNVTxKQgDgZ8_EwBwIBKgICBTmjVzBVMFMGCysGAQQBizpzeQEoAQH_BEEEBf4waGibxLr-xOtIPTqSyPUm7VhND0Wemc6TpRIpCgQVYa-Hh9BK_SkBIguxAbZb1l_SGiHV9mTj-uzDq4UDCTAJBgcqhkjOPQQCA0IAwzeiNwHfnk9f9Npkh9_iWLl6DV8VIdqCc_Dud-yygJ0Qlt_rRzooGOfmi3uaeBwLO5hPOCkbRPVKJo989qd7hBsCAQEwgfwEQQQetkj_nYGbQHpsWNJ5eHI8TltFCsmJgzzs9v2HwxYM3gmt2VZXjp4go3k37qEfTU2rXXKDOCK7sM0lL_g54kG3BCAoyU3VhYrmjwVHG9q6GJc9HM88VSjvfKl5L2gGR8sXaARBBCuONwsSB9Elx41TAs_HPLwWHh3xXgxfrzgjy1qpzdiUBiv-iUljSzooGoQBeMBczcmtts1rujewpgQ4U9-i5V8EUjBYNUY3QkZFNzUyQUMxQTQ1RjY3NDk3RDlEQ0REOUJCREE1MEE4Mzk1NcBxJpS6VWwViG_3TFMX3w_C5Rk1h9lTxNkbTSZP6dyrAAABgOG0yDgwggFHMIH4BgcqhkjOPQIBMIHsAgEBMCUGByqGSM49AQIwGgICARsGCSqGSM49AQIDAzAJAgEFAgEHAgEMMEwEJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBEkEBQMhP3jKRIg_GjuBYvGI5VPNJl8jwVZ6FodpE7DCrCRYSSg2AczaOA8cnjGNkPldB-VCb-h-RcDoGEaY5FliNk40EWF33SJZAiQB_______________________pri7QdXcmXf9_lEUeBh4WPGECAQQDSgAEByc72m2s0_jBop-62ySxOmAR5gw32JVHF50_cmbjxnFYwHEsAUMY0LO578TX5xO7FMuir1CEu8V1tiq1TpyIOVz-M_xl84Hr\\\",\\\"description\\\":\\\"Prove that the \\\\\\\"identifier\\\\\\\" is the identifier hidden in attestation contained in\\\\\\\"payload\\\\\\\".\\\",\\\"timestamp\\\":\\\"Fri May 20 2022 13:42:44 GMT+0000\\\",\\\"identifier\\\":\\\"email@test.com\\\",\\\"expirationTime\\\":\\\"Sat May 20 2023 13:42:44 GMT+0000\\\"},\\\"domain\\\":{\\\"name\\\":\\\"https://www.hotelbogota.com\\\",\\\"version\\\":\\\"0.1\\\",\\\"chainId\\\":0}}\"}";
     Eip712AttestationUsage request = new Eip712AttestationUsage(DOMAIN, attestorKeys.getPublic(), Timestamp.UNLIMITED, 0, jsonInvalidSig);
-    AsymmetricKeyParameter candidateKey = request.retrieveUserPublicKey(request.getJsonEncoding(),  Eip712AttestationRequestWithUsageEncoder.AttestationRequestWUsageData.class);
+    AsymmetricKeyParameter candidateKey = request.retrieveUserPublicKey(request.getJsonEncoding(), Eip712AttestationRequestWithUsageEncoder.AttestationRequestWUsageData.class);
     assertNotEquals(userAddress, SignatureUtility.addressFromKey(candidateKey));
   }
 
   @Test
-  public void validateWrongNonceKey() {
+  void validateWrongNonceKey() {
     // Notice the wrong address
     byte[] nonce = Nonce.makeNonce("0x1234567890123456789012345678901234567890", DOMAIN, new Timestamp());
     FullProofOfExponent pok = crypto.computeAttestationProof(ATTESTATION_SECRET, nonce);


### PR DESCRIPTION
Added functionality to the test suite of attestation.jar to generate files with test keys and attestations, etc. which can be used for testing Authenticator.
See issue #282
This closes issue #280 