### PR TITLE
Feature: dynamic asn parser

### DIFF
--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -11,6 +11,7 @@
     "pack": "webpack",
     "clean": "rm -R dist",
     "watch": "webpack --watch --progress",
+    "serve": "webpack serve",
     "testjest": "jest",
     "prepublishOnly": "npm run clean && npm run build"
   },

--- a/src/main/javascript/crypto/parser-test.html
+++ b/src/main/javascript/crypto/parser-test.html
@@ -7,8 +7,93 @@
  </head>
  <body>
     <script>
+        function test(){
+			let generatedSchema = new SchemaGenerator({
+				ticket: {
+					name: "Ticket",
+					items: {
+						devconId: {
+							type: "Utf8String",
+							optional: false
+						},
+						ticketIdNumber: {
+							type: "Integer",
+							optional: true
+						},
+						ticketIdString: {
+							type: "Utf8String",
+							optional: true
+						},
+						ticketClass: {
+							type: "Integer",
+							optional: false
+						},
+						linkedTicket: {
+							name: "Linked Ticket",
+							items: {
+								devconId: {
+									type: "Utf8String",
+									optional: false
+								},
+								ticketIdNumber: {
+									type: "Integer",
+									optional: true
+								},
+								ticketIdString: {
+									type: "Utf8String",
+									optional: true
+								},
+								ticketClass: {
+									type: "Integer",
+									optional: false
+								}
+							}
+						}
+					}
+				},
+				commitment: {
+					type: "OctetString",
+					optional: true
+				},
+				signatureValue: {
+					type: "BitString",
+					optional: false
+				}
+			});
 
+			let asnObject = generatedSchema.getSchemaObject();
+
+			asnObject.ticket.devconId = "6";
+			asnObject.ticket.ticketIdNumber = 10;
+			asnObject.ticket.ticketClass = 1;
+
+			asnObject.ticket.linkedTicket.devconId = "6";
+			asnObject.ticket.linkedTicket.ticketIdNumber = 10;
+			asnObject.ticket.linkedTicket.ticketClass = 1;
+
+			asnObject.signatureValue = new Uint8Array([
+				177,  53, 222, 215,  60,   2,  17, 132,  21, 143, 166,
+				234, 145, 239, 240, 169, 119,  83, 242, 113,  99, 243,
+				179,  90,  87, 211, 250, 197, 113,  70, 191,  10,  69,
+				121,  82,  36, 254, 251, 149, 237, 222, 125, 213,  90,
+				21,  84, 130, 155,  91, 226,  15,  62,  57, 177, 251,
+				39, 165,  43, 214,  57, 114, 209, 232, 156,  28
+			]);
+
+			console.log("Populated schema object: ");
+			console.log(asnObject);
+
+			let encoded = generatedSchema.serializeAndFormat(asnObject);
+
+			console.log("Encoded: ");
+			console.log(encoded);
+
+			let decoded = generatedSchema.parse(encoded);
+
+			console.log("Decoded: ");
+			console.log(decoded);
+        }
     </script>
-    <button onclick="(new Meh()).meh();">Run Test</button>
+    <button onclick="test();">Run Test</button>
  </body>
 </html>

--- a/src/main/javascript/crypto/parser-test.html
+++ b/src/main/javascript/crypto/parser-test.html
@@ -1,0 +1,14 @@
+<html>
+ <head>
+     <script>
+		 process = {env: {NODE_DEBUG: "false"}};
+     </script>
+     <script type="text/javascript" src="dist/authenticator.bundle.js"></script>
+ </head>
+ <body>
+    <script>
+
+    </script>
+    <button onclick="(new Meh()).meh();">Run Test</button>
+ </body>
+</html>

--- a/src/main/javascript/crypto/src/bundle.ts
+++ b/src/main/javascript/crypto/src/bundle.ts
@@ -2,11 +2,10 @@ import {Authenticator} from "./Authenticator";
 import {Eip712AttestationRequest} from "./libs/Eip712AttestationRequest";
 import {AttestationCrypto} from "./libs/AttestationCrypto";
 import {IntegrationExample} from "./IntegrationExample";
-import {Meh, SchemaGenerator} from "./util/SchemaGenerator";
+import {SchemaGenerator} from "./util/SchemaGenerator";
 
 (window as any).Authenticator = Authenticator;
 (window as any).Attest = Eip712AttestationRequest;
 (window as any).AttestationCrypto = AttestationCrypto;
 (window as any).IntegrationExample = IntegrationExample;
 (window as any).SchemaGenerator = SchemaGenerator;
-(window as any).Meh = Meh;

--- a/src/main/javascript/crypto/src/bundle.ts
+++ b/src/main/javascript/crypto/src/bundle.ts
@@ -2,8 +2,11 @@ import {Authenticator} from "./Authenticator";
 import {Eip712AttestationRequest} from "./libs/Eip712AttestationRequest";
 import {AttestationCrypto} from "./libs/AttestationCrypto";
 import {IntegrationExample} from "./IntegrationExample";
+import {Meh, SchemaGenerator} from "./util/SchemaGenerator";
 
 (window as any).Authenticator = Authenticator;
 (window as any).Attest = Eip712AttestationRequest;
 (window as any).AttestationCrypto = AttestationCrypto;
 (window as any).IntegrationExample = IntegrationExample;
+(window as any).SchemaGenerator = SchemaGenerator;
+(window as any).Meh = Meh;

--- a/src/main/javascript/crypto/src/main.spec.ts
+++ b/src/main/javascript/crypto/src/main.spec.ts
@@ -31,6 +31,15 @@ import {Issuer} from "./libs/Issuer";
 import { AttestedObject } from './libs/AttestedObject';
 import { AttestableObject } from './libs/AttestableObject';
 import { UseToken } from './asn1/shemas/UseToken';
+import subtle from "./safe-connect/SubtleCryptoShim";
+import {EthereumAddressAttestation} from "./safe-connect/EthereumAddressAttestation";
+import {EthereumKeyLinkingAttestation} from "./safe-connect/EthereumKeyLinkingAttestation";
+import {SchemaGenerator} from "./util/SchemaGenerator";
+import {DevconTicket, SignedDevconTicket} from "./asn1/shemas/SignedDevconTicket";
+import * as util from "util";
+import * as asn1_schema_1 from "@peculiar/asn1-schema";
+import {AsnParser, AsnPropTypes, AsnSerializer} from "@peculiar/asn1-schema";
+import {utils} from "ethers";
 const url = require('url');
 
 let EC = require("elliptic");
@@ -675,5 +684,39 @@ describe("read attested object", () => {
 
     })
 })
+
+describe("Schema Generator", function(){
+
+    test("Serialize & parse ASN based on a dynamic schema", async function(){
+
+        let schemaGenerator = new SchemaGenerator();
+
+        let GeneratedSchema = schemaGenerator.getSchemaObject();
+
+        console.log(util.inspect(GeneratedSchema));
+
+        let currentSchema = new GeneratedSchema();
+
+        currentSchema.ticket.devconId = "6";
+        currentSchema.ticket.ticketIdNumber = 10;
+        currentSchema.ticket.ticketClass = 1;
+
+        currentSchema.ticket.linkedTicket.devconId = "6";
+        currentSchema.ticket.linkedTicket.ticketIdNumber = 10;
+        currentSchema.ticket.linkedTicket.ticketClass = 1;
+
+        currentSchema.signatureValue = new Uint8Array(hexStringToUint8("0xb135ded73c021184158fa6ea91eff0a97753f27163f3b35a57d3fac57146bf0a45795224fefb95edde7dd55a1554829b5be20f3e39b1fb27a52bd63972d1e89c1c"));
+
+        console.log(currentSchema);
+
+        let encoded = AsnSerializer.serialize(currentSchema);
+
+        console.log(uint8tohex(new Uint8Array(encoded)));
+
+        let decoded = AsnParser.parse(encoded, GeneratedSchema);
+
+        console.log(decoded);
+    });
+});
 
 

--- a/src/main/javascript/crypto/src/util/SchemaGenerator.ts
+++ b/src/main/javascript/crypto/src/util/SchemaGenerator.ts
@@ -1,0 +1,189 @@
+import * as asn1_schema_1 from "@peculiar/asn1-schema";
+import {AsnParser, AsnPropTypes, AsnSerializer} from "@peculiar/asn1-schema";
+import {hexStringToUint8, uint8tohex} from "../libs/utils";
+import {AsnItemType, AsnRepeatType, IAsn1PropOptions} from "@peculiar/asn1-schema/build/types/decorators";
+import {IAsnConverter} from "@peculiar/asn1-schema/build/types/types";
+
+interface SchemaDefinitionInterface {
+	[key: string]: SchemaItemInterface
+}
+
+interface SchemaItemInterface {
+	name?: string;
+	items?: SchemaDefinitionInterface,
+	type?: AsnItemType | string;
+	optional?: boolean;
+	defaultValue?: any;
+	context?: number;
+	implicit?: boolean;
+	converter?: IAsnConverter;
+	repeated?: AsnRepeatType;
+}
+
+export class SchemaGenerator {
+
+	jsonSchema: any;
+
+	schemaObject: any;
+
+	private static __decorate = function (decorators: any, target: any, key: any, desc: any) {
+		var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+		// @ts-ignore
+		if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+		else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+		return c > 3 && r && Object.defineProperty(target, key, r), r;
+	};
+
+	constructor(jsonSchema: SchemaDefinitionInterface = {
+		ticket: {
+			name: "Ticket",
+			items: {
+				devconId: {
+					type: "Utf8String",
+					optional: false
+				},
+				ticketIdNumber: {
+					type: "Integer",
+					optional: true
+				},
+				ticketIdString: {
+					type: "Utf8String",
+					optional: true
+				},
+				ticketClass: {
+					type: "Integer",
+					optional: false
+				},
+				linkedTicket: {
+					name: "Linked Ticket",
+					items: {
+						devconId: {
+							type: "Utf8String",
+							optional: false
+						},
+						ticketIdNumber: {
+							type: "Integer",
+							optional: true
+						},
+						ticketIdString: {
+							type: "Utf8String",
+							optional: true
+						},
+						ticketClass: {
+							type: "Integer",
+							optional: false
+						}
+					}
+				}
+			}
+		},
+		commitment: {
+			type: AsnPropTypes.OctetString,
+			optional: true
+		},
+		signatureValue: {
+			type: AsnPropTypes.BitString,
+			optional: false
+		}
+	}) {
+		this.jsonSchema = jsonSchema;
+
+		this.schemaObject = this.generateSchema();
+	}
+
+	private generateSchema(): any {
+
+		let Schema: any = class {};
+
+		for (let i in this.jsonSchema){
+
+			if (this.jsonSchema[i].items){
+
+				let childSchemaGenerator: any = new SchemaGenerator(this.jsonSchema[i].items);
+				let childSchema = childSchemaGenerator.getSchemaObject();
+
+				Schema.prototype[i] = new childSchema();
+
+				SchemaGenerator.__decorate([
+					(asn1_schema_1.AsnProp)(this.getDecoratorOptions({ type: childSchema }))
+				], Schema.prototype, i, void 0);
+
+			} else {
+				SchemaGenerator.__decorate([
+					(asn1_schema_1.AsnProp)(this.getDecoratorOptions(this.jsonSchema[i]))
+				], Schema.prototype, i, void 0);
+			}
+
+		}
+
+		return Schema;
+	}
+
+	private getDecoratorOptions(item: SchemaItemInterface){
+
+		let type: AsnPropTypes;
+
+		if (typeof item.type === "string"){
+			if (!(item.type in AsnPropTypes))
+				throw new Error("Non-existent AsnPropType " + item.type);
+
+			type = AsnPropTypes[item.type as any] as unknown as AsnPropTypes;
+		} else {
+			type = item.type as AsnPropTypes;
+		}
+
+		let decoratorOptions: IAsn1PropOptions = {
+			type: type,
+			optional: item.optional,
+			defaultValue: item.defaultValue,
+			context: item.context,
+			implicit: item.implicit,
+			converter: item.converter,
+			repeated: item.repeated
+		}
+
+		return decoratorOptions;
+	}
+
+	getSchemaObject(){
+		return this.schemaObject;
+	}
+
+
+}
+
+export class Meh {
+
+	meh() {
+
+		let schemaGenerator = new SchemaGenerator();
+
+		let GeneratedSchema = schemaGenerator.getSchemaObject();
+
+		console.log("The full schema object");
+		console.log(GeneratedSchema);
+
+		let currentSchema = new GeneratedSchema();
+
+		currentSchema.ticket.devconId = "6";
+		currentSchema.ticket.ticketIdNumber = 10;
+		currentSchema.ticket.ticketClass = 1;
+
+		currentSchema.ticket.linkedTicket.devconId = "6";
+		currentSchema.ticket.linkedTicket.ticketIdNumber = 10;
+		currentSchema.ticket.linkedTicket.ticketClass = 1;
+
+		currentSchema.signatureValue = new Uint8Array(hexStringToUint8("0xb135ded73c021184158fa6ea91eff0a97753f27163f3b35a57d3fac57146bf0a45795224fefb95edde7dd55a1554829b5be20f3e39b1fb27a52bd63972d1e89c1c"));
+
+		console.log("Populated schema object");
+		console.log(currentSchema);
+
+		let encoded = AsnSerializer.serialize(currentSchema);
+
+		console.log(uint8tohex(new Uint8Array(encoded)));
+
+		let decoded = AsnParser.parse(encoded, GeneratedSchema);
+
+		console.log(decoded);
+	}
+}

--- a/src/main/javascript/crypto/webpack.config.js
+++ b/src/main/javascript/crypto/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 module.exports = {
     entry: './src/bundle.ts',
+    mode: "development",
     module: {
         rules: [
             {
@@ -12,6 +13,13 @@ module.exports = {
                 ]
             }
             ]
+    },
+    devServer: {
+        static: {
+            directory: path.join(__dirname, '/'),
+        },
+        compress: true,
+        port: 3015,
     },
     resolve: {
         extensions: [ '.tsx', '.ts', '.js' ],


### PR DESCRIPTION
Hey @weiwu-zhang 

Here is an examples of how the asn1-schema library can be utilized to serialize & parse ASN using a schema provided at runtime. 
The schema input is currently in JSON, but we can easily bridge the gap from .asd by writing an XML converter that can output this structure. Choice functionality will also need to be added to provide full support for ASN1.