### PR TITLE
Various fixes & enhancements for Devcon use cases

### DIFF
--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.3.9-sc.6",
+  "version": "0.3.9-dc.1",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.3.9-dc.2",
+  "version": "0.3.9-dc.3",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.3.9-dc.1",
+  "version": "0.3.9-dc.2",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/src/Authenticator.ts
+++ b/src/main/javascript/crypto/src/Authenticator.ts
@@ -144,7 +144,7 @@ export class Authenticator {
     }
 
     // TODO: Pass in Ticket schema object
-    static validateUseTicket(proof:string, base64attestorPublicKey:string, base64issuerPublicKeys: {[key: string]: KeyPair|string}, userEthKey:string){
+    static validateUseTicket(proof:string, base64attestorPublicKey:string, base64issuerPublicKeys: {[key: string]: KeyPair|string}, userEthKey: string|null){
 
         let attestorKey = KeyPair.publicFromBase64orPEM(base64attestorPublicKey);
         let issuerKeys = KeyPair.parseKeyArrayStrings(base64issuerPublicKeys);

--- a/src/main/javascript/crypto/src/Ticket.ts
+++ b/src/main/javascript/crypto/src/Ticket.ts
@@ -127,6 +127,10 @@ export class Ticket extends AttestableObject implements Attestable {
         return this.ticketClass;
     }
 
+	public getDevconId(){
+		return this.devconId;
+	}
+
     public getSignature(): string {
         return this.signature;
     }

--- a/src/main/javascript/crypto/src/libs/AttestedObject.ts
+++ b/src/main/javascript/crypto/src/libs/AttestedObject.ts
@@ -227,6 +227,9 @@ export class AttestedObject implements ASNEncodable, Verifiable {
             return false;
         }
 
+		if (ethAddress === null)
+			return true;
+
         try {
 
             // CHECK: the Ethereum address on the attestation matches receivers signing key


### PR DESCRIPTION
Hey @oleggrib 

Please review these changes when you get a chance:

- Fix: Issuer keys object being overwritten when importing into KeyPair objects. 
- Feature: return AttestedObject from Authenticator.validateUseTicket on successful validation. 
  This allow the validator to access attestation ticket data without subsequent decoding of the attestation. 
- Feature: allow validateUseTicket without userEthKey check by explicitly passing null for userEthKey argument. 