### PR TITLE
Fix/breaking change erc721

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can always use this project in your own code through Maven central, by addin
  <dependency>
    <groupId>org.tokenscript</groupId>
    <artifactId>attestation</artifactId>
-   <version>0.4</version>
+   <version>0.4.1</version>
  </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ task testJavaScript(type: NodeTask) {
 
 group = 'org.tokenscript'
 archivesBaseName = 'attestation'
-version = '0.4'
+version = '0.4.1'
 
 /** See https://docs.gradle.org/current/userguide/publishing_maven.html for details
  * For actually updating the Maven repo update the version reference in README.md,

--- a/src/intTest/java/io/alchemynft/attestation/NFTSmartContractTest.java
+++ b/src/intTest/java/io/alchemynft/attestation/NFTSmartContractTest.java
@@ -1,19 +1,20 @@
 package io.alchemynft.attestation;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.alphawallet.ethereum.AttestationReturn;
 import com.alphawallet.token.tools.Numeric;
+import java.security.SecureRandom;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.tokenscript.attestation.ERC721Token;
 import org.tokenscript.attestation.IdentifierAttestation;
 import org.tokenscript.attestation.SignedIdentifierAttestation;
 import org.tokenscript.attestation.core.SignatureUtility;
 import org.tokenscript.attestation.demo.SmartContract;
-
-import java.security.SecureRandom;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class NFTSmartContractTest {
     private static AsymmetricCipherKeyPair subjectKeys;
@@ -84,8 +85,9 @@ public class NFTSmartContractTest {
         assertTrue(atr.isValid);
         for (int index = 0; index < atr.ercToken.length; index++)
         {
-            assertEquals(atr.ercToken[index].address.toString().toLowerCase(), myNFTs[index].getAddress().toLowerCase());
-            assertEquals(atr.ercToken[index].tokenId.getValue(), myNFTs[index].getTokenIds().get(0));
+            assertEquals(atr.ercToken[index].address.toString().toLowerCase(),
+                myNFTs[index].getAddress().toLowerCase());
+            assertEquals(atr.ercToken[index].tokenId.getValue(), myNFTs[index].getTokenId());
         }
 
         //TODO: make a more comprehensive negative test, involving bad attestation subject address etc.

--- a/src/main/java/io/alchemynft/attestation/ERC721Token.java
+++ b/src/main/java/io/alchemynft/attestation/ERC721Token.java
@@ -1,0 +1,103 @@
+package io.alchemynft.attestation;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERSequence;
+import org.tokenscript.attestation.core.ASNEncodable;
+import org.tokenscript.attestation.core.ExceptionUtil;
+import org.web3j.utils.Numeric;
+
+/**
+ * Legacy class only used in Alchemy nft attestation. For any other use, use ERC721Token from
+ * org.tokenscript.attestation
+ */
+@Deprecated
+class ERC721Token implements ASNEncodable {
+
+  private static final Logger logger = LogManager.getLogger(ERC721Token.class);
+
+  private final byte[] encoding;
+  private final String address;
+  private final BigInteger tokenId;
+
+  public ERC721Token(String address, String tokenId) {
+    this.address = address.toLowerCase();
+    BigInteger tokenIdInteger;
+    try {
+      tokenIdInteger = new BigInteger(tokenId);
+    } catch (Exception e) {
+      tokenIdInteger = BigInteger.ZERO;
+    }
+    validateID(tokenIdInteger);
+    this.tokenId = tokenIdInteger;
+    this.encoding = constructEncoding();
+  }
+
+  public ERC721Token(String address, BigInteger tokenId) {
+    this.address = address.toLowerCase();
+    validateID(tokenId);
+    this.tokenId = tokenId;
+    this.encoding = constructEncoding();
+  }
+
+  public ERC721Token(byte[] derEncoding) throws IOException {
+    ASN1InputStream input = null;
+    try {
+      input = new ASN1InputStream(derEncoding);
+      ASN1Sequence asn1 = ASN1Sequence.getInstance(input.readObject());
+      ASN1OctetString address = DEROctetString.getInstance(asn1.getObjectAt(0));
+      ASN1OctetString tokenId = DEROctetString.getInstance(asn1.getObjectAt(1));
+      // Remove the # added by BouncyCastle
+      this.address = address.toString().substring(1);
+      this.tokenId = new BigInteger(1, tokenId.getOctets());
+      this.encoding = constructEncoding();
+    } finally {
+      input.close();
+    }
+  }
+
+  private void validateID(BigInteger tokenId) {
+    // Only allow non-negative IDs
+    if (tokenId.compareTo(BigInteger.ZERO) < 0) {
+      throw ExceptionUtil.throwException(logger,
+          new IllegalArgumentException("IDs cannot be negative"));
+    }
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public BigInteger getTokenId() {
+    return tokenId;
+  }
+
+
+  @Override
+  public byte[] getDerEncoding() {
+    return encoding;
+  }
+
+  byte[] constructEncoding() {
+    ASN1EncodableVector data = getTokenVector();
+    try {
+      return new DERSequence(data).getEncoded();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public ASN1EncodableVector getTokenVector() {
+    ASN1EncodableVector data = new ASN1EncodableVector();
+    data.add(new DEROctetString(Numeric.hexStringToByteArray(address)));
+    data.add(new DEROctetString(tokenId.toByteArray()));
+    return data;
+  }
+}

--- a/src/main/java/io/alchemynft/attestation/ERC721Token.java
+++ b/src/main/java/io/alchemynft/attestation/ERC721Token.java
@@ -19,7 +19,7 @@ import org.web3j.utils.Numeric;
  * org.tokenscript.attestation
  */
 @Deprecated
-class ERC721Token implements ASNEncodable {
+public class ERC721Token implements ASNEncodable {
 
   private static final Logger logger = LogManager.getLogger(ERC721Token.class);
 

--- a/src/main/java/io/alchemynft/attestation/NFTAttestation.java
+++ b/src/main/java/io/alchemynft/attestation/NFTAttestation.java
@@ -12,7 +12,6 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.util.PublicKeyFactory;
 import org.tokenscript.attestation.AttestedKeyObject;
-import org.tokenscript.attestation.ERC721Token;
 import org.tokenscript.attestation.SignedIdentifierAttestation;
 import org.tokenscript.attestation.core.ExceptionUtil;
 

--- a/src/main/java/io/alchemynft/attestation/NFTAttestationDecoder.java
+++ b/src/main/java/io/alchemynft/attestation/NFTAttestationDecoder.java
@@ -5,7 +5,6 @@ import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
-import org.tokenscript.attestation.ERC721Token;
 import org.tokenscript.attestation.ObjectDecoder;
 import org.tokenscript.attestation.SignedIdentifierAttestation;
 

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.4.1",
+  "version": "0.4",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -29,7 +29,7 @@
     "@types/chai": "^4.3.4",
     "@types/jest": "^27.5.2",
     "@types/mocha": "^8.2.3",
-    "@types/node": "^17.0.45",
+    "@types/node": "^18.11.9",
     "@types/pvutils": "^1.0.1",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.4",
+  "version": "0.4.1",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -43,7 +43,7 @@
     "ts-loader": "^9.4.1",
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4",
+    "typescript": "^4.9.3",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0"
   },

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.4",
+  "version": "0.4.1",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/src/asn1/shemas/NFTAttestation.ts
+++ b/src/main/javascript/crypto/src/asn1/shemas/NFTAttestation.ts
@@ -9,7 +9,8 @@ import {UriIdAttestation} from "./UriIdAttestation";
 
 export class ERC721 {
     @AsnProp({ type: AsnPropTypes.OctetString }) public address: Uint8Array;
-    @AsnProp({ type: AsnPropTypes.OctetString }) public tokenId: Uint8Array;
+    @AsnProp({ type: AsnPropTypes.OctetString, optional: true }) public tokenId: Uint8Array;
+    @AsnProp({ type: AsnPropTypes.Integer, optional: true }) public chainId: number;
 }
 
 // Tokens ::= SEQUENCE SIZE (1..MAX) OF ERC721

--- a/src/main/javascript/crypto/src/asn1/shemas/NFTAttestation.ts
+++ b/src/main/javascript/crypto/src/asn1/shemas/NFTAttestation.ts
@@ -9,8 +9,7 @@ import {UriIdAttestation} from "./UriIdAttestation";
 
 export class ERC721 {
     @AsnProp({ type: AsnPropTypes.OctetString }) public address: Uint8Array;
-    @AsnProp({ type: AsnPropTypes.OctetString, optional: true }) public tokenId: Uint8Array;
-    @AsnProp({ type: AsnPropTypes.Integer, optional: true }) public chainId: number;
+    @AsnProp({ type: AsnPropTypes.OctetString }) public tokenId: Uint8Array;
 }
 
 // Tokens ::= SEQUENCE SIZE (1..MAX) OF ERC721

--- a/src/test/java/io/alchemynft/attestation/NFTAttestationTest.java
+++ b/src/test/java/io/alchemynft/attestation/NFTAttestationTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.tokenscript.attestation.ERC721Token;
 import org.tokenscript.attestation.HelperTest;
 import org.tokenscript.attestation.IdentifierAttestation;
 import org.tokenscript.attestation.SignedIdentifierAttestation;


### PR DESCRIPTION
Handles an issue with legacy compatibility with Alchemy NFT attestations and the format of ERC 721 tokens. 
Basically ensuring backward compatibility by also supporting the legacy ERC721 token format used in  Alchemy NFT attestations.