### PR TITLE
fix: various fixes for EAS

### DIFF
--- a/src/main/javascript/crypto/package-lock.json
+++ b/src/main/javascript/crypto/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.5.0",
+  "version": "0.5.1-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenscript/attestation",
-      "version": "0.5.0",
+      "version": "0.5.1-beta.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/src/main/javascript/crypto/package-lock.json
+++ b/src/main/javascript/crypto/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.5.1-beta.2",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenscript/attestation",
-      "version": "0.5.1-beta.2",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.5.1-beta.2",
+  "version": "0.5.1",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/package.json
+++ b/src/main/javascript/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/attestation",
-  "version": "0.5.0",
+  "version": "0.5.1-beta.2",
   "description": "A library for integrating cryptographic attestations into applications",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/main/javascript/crypto/src/Authenticator.ts
+++ b/src/main/javascript/crypto/src/Authenticator.ts
@@ -144,8 +144,7 @@ export class Authenticator {
 
     }
 
-    // TODO: Pass in Ticket schema object
-    static validateUseTicket(proof:string, base64attestorPublicKey:string, base64issuerPublicKeys: {[key: string]: KeyPair|string}, userEthKey: string){
+    static validateUseTicket(proof:string, base64attestorPublicKey:string, base64issuerPublicKeys: {[key: string]: KeyPair|string}, userEthKey?: string){
 
         let attestorKey = KeyPair.publicFromBase64orPEM(base64attestorPublicKey);
         let issuerKeys = KeyPair.parseKeyArrayStrings(base64issuerPublicKeys);

--- a/src/main/javascript/crypto/src/Ticket.ts
+++ b/src/main/javascript/crypto/src/Ticket.ts
@@ -142,8 +142,10 @@ export class Ticket extends AttestableObject implements Attestable {
 
 		for (const key of this.issuerKeys){
 
-			if (pubKey.substring(2) === key.getPublicKeyAsHexStr())
-				return true;
+			if (pubKey.substring(2) === key.getPublicKeyAsHexStr()) {
+                this.key = key;
+                return true;
+            }
 		}
 
 		throw new Error("Ticket signature is invalid");

--- a/src/main/javascript/crypto/src/eas/AttestationUrl.ts
+++ b/src/main/javascript/crypto/src/eas/AttestationUrl.ts
@@ -51,16 +51,6 @@ export type CompactLightweightAttestationShareablePackageObject = [
 	nonce: number
 ];
 
-export interface StaticSchemaInformation {
-	domain: {
-		version: string,
-		chainId: number,
-		verifyingContract: string,
-	},
-	schema: string,
-	signer: string,
-}
-
 export function zipAndEncodeToBase64(
 	qrPackage: AttestationShareablePackageObject,
 ) {

--- a/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
+++ b/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
@@ -122,8 +122,7 @@ export class EasTicketAttestation extends AttestableObject implements Attestable
 			let value = data[field.name]
 
 			if (field.isCommitment){
-				if (!this.commitmentSecret)
-					this.commitmentSecret = this.crypto.makeSecret();
+				this.commitmentSecret = this.crypto.makeSecret();
 
 				value = this.createCommitment(value as string, commitmentType, this.commitmentSecret);
 			}

--- a/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
+++ b/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
@@ -111,6 +111,9 @@ export class EasTicketAttestation extends AttestableObject implements Attestable
 		if (!this.signerAddress)
 			new Error("Failed to get signer address");
 
+		// New secret generated for each attestation
+		this.commitmentSecret = undefined;
+
 		const fieldData = this.schema.fields.map((field) => {
 
 			if (!data[field.name])

--- a/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
+++ b/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
@@ -266,7 +266,9 @@ export class EasTicketAttestation extends AttestableObject implements Attestable
 		// Expiry check
 		this.checkValidity();
 
-		await this.checkRevocation()
+		// EAS registry check to make sure attestation is not revoked
+		if(this.signedAttestation.message.revocable)
+			await this.checkRevocation()
 	}
 
 	private async checkRevocation(uid?: string){

--- a/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
+++ b/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
@@ -234,13 +234,11 @@ export class EasTicketAttestation extends AttestableObject implements Attestable
 		return this.decodedData;
 	}
 
-	getAttestationField(fieldName: string, suppressException = false){
+	getAttestationField(fieldName: string){
 
 		const data = this.getAttestationData();
 
 		if (!data[fieldName]) {
-			if (suppressException)
-				return false;
 			throw new Error("The attestation does not contain data field '" + fieldName + "'");
 		}
 

--- a/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
+++ b/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
@@ -13,8 +13,7 @@ import {hexStringToUint8, uint8tohex} from "../libs/utils";
 import {OffchainAttestationParams} from "@ethereum-attestation-service/eas-sdk/dist/offchain/offchain";
 import {Attestable} from "../libs/Attestable";
 import {AttestableObject} from "../libs/AttestableObject";
-import {SignerOrProvider} from "@ethereum-attestation-service/eas-sdk/dist/transaction";
-import {decodeBase64ZippedBase64, StaticSchemaInformation, zipAndEncodeToBase64} from "./AttestationUrl";
+import {decodeBase64ZippedBase64, zipAndEncodeToBase64} from "./AttestationUrl";
 import {KeyPair, KeysArray} from "../libs/KeyPair";
 import {EIP712DomainTypedData} from "@ethereum-attestation-service/eas-sdk/dist/offchain/typed-data-handler";
 import * as pako from "pako";
@@ -334,10 +333,6 @@ export class EasTicketAttestation extends AttestableObject implements Attestable
 
 	loadFromEncoded(
 		base64: string,
-		/**
-		 * @deprecated Use ASN.1 encoding to reduce size instead
-		 */
-		schemaInfo?: StaticSchemaInformation,
 		keys?: KeysArray,
 		commitmentSecret?: string){
 		const decoded = decodeBase64ZippedBase64(base64);

--- a/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
+++ b/src/main/javascript/crypto/src/eas/EasTicketAttestation.ts
@@ -50,8 +50,6 @@ export interface EasTicketCreationOptions {
 	validity?: {from: number, to: number}
 }
 
-export type EASSignerOrProvider = SignerOrProvider;
-
 export class  EasAsnEmbeddedSchema {
 	@AsnProp({ type: AsnPropTypes.OctetString })
 	public easAttestation: Uint8Array
@@ -446,7 +444,9 @@ export class EasTicketAttestation extends AttestableObject implements Attestable
 
 	private processKeysParam(keys?: KeysArray){
 
-		let conferenceId = this.getAttestationField("devconId", true);
+		const data = this.getAttestationData();
+
+		let conferenceId = data.eventId ?? data.devconId ?? "";
 
 		if (!keys){
 			if (!this.issuerKeys){
@@ -454,9 +454,6 @@ export class EasTicketAttestation extends AttestableObject implements Attestable
 			}
 			keys = this.issuerKeys;
 		}
-
-		if (!conferenceId)
-			conferenceId = "";
 
 		if (!keys[conferenceId]){
 			if (!conferenceId || (conferenceId && !keys[""])){

--- a/src/main/javascript/crypto/src/eas/EasZkProof.ts
+++ b/src/main/javascript/crypto/src/eas/EasZkProof.ts
@@ -1,20 +1,16 @@
 import {SignedIdentifierAttestation} from "../libs/SignedIdentifierAttestation";
 import {base64ToUint8array, hexStringToBase64, logger} from "../libs/utils";
 import {KeyPair, KeysArray, KeysConfig} from "../libs/KeyPair";
-import {EASSignerOrProvider, EasTicketAttestation, TicketSchema} from "./EasTicketAttestation";
+import {EasTicketAttestation, TicketSchema} from "./EasTicketAttestation";
 import {AttestedObject} from "../libs/AttestedObject";
 import {UseToken} from "../asn1/shemas/UseToken";
 import {DEBUGLEVEL} from "../config";
 
 export class EasZkProof {
 
-	constructor(private schema: TicketSchema,
-				private EASconfig: {
-					address: string // EAS resolver contract address
-					version: string
-					chainId: number
-				},
-				private provider: EASSignerOrProvider
+	constructor(
+		private schema: TicketSchema,
+		private rpcMap: {[chainId: number]: string}
 	) {
 
 	}
@@ -35,7 +31,7 @@ export class EasZkProof {
 		}
 
 		const idAttest = SignedIdentifierAttestation.fromBytes(base64ToUint8array(base64IdentifierAttestation), KeyPair.publicFromBase64orPEM(attestorPublicKey));
-		const ticketAttest = new EasTicketAttestation(this.schema, this.EASconfig, this.provider);
+		const ticketAttest = new EasTicketAttestation(this.schema, undefined, this.rpcMap);
 
 		ticketAttest.loadFromEncoded(base64TicketAttestation, undefined,  <KeysArray>base64senderPublicKeys);
 
@@ -52,31 +48,22 @@ export class EasZkProof {
 		let attestorKey = KeyPair.publicFromBase64orPEM(base64attestorPublicKey);
 		let issuerKeys = KeyPair.parseKeyArrayStrings(base64issuerPublicKeys);
 
-		try {
+		const self = this;
 
-			const self = this;
-
-			const EasValidationWrapper = class extends EasTicketAttestation {
-				constructor() {
-					super(self.schema, self.EASconfig, self.provider);
-				}
-			}
-
-			let decodedAttestedObject = AttestedObject.fromBytes(base64ToUint8array(proof), UseToken, attestorKey, EasValidationWrapper, issuerKeys);
-
-			if (!decodedAttestedObject.checkValidity(userEthKey)){
-				throw new Error("Ticket validity check failed!");
-			}
-
-			await (decodedAttestedObject.getAttestableObject() as EasTicketAttestation).validateEasAttestation()
-
-			return decodedAttestedObject;
-
-		} catch (e) {
-			if (e instanceof Error) {
-				let message = "Ticket proof validation failed! " + e.message;
-				throw new Error(message);
+		const EasValidationWrapper = class extends EasTicketAttestation {
+			constructor() {
+				super(self.schema, undefined, self.rpcMap, issuerKeys);
 			}
 		}
+
+		let decodedAttestedObject = AttestedObject.fromBytes(base64ToUint8array(proof), UseToken, attestorKey, EasValidationWrapper, issuerKeys);
+
+		if (!decodedAttestedObject.checkValidity(userEthKey)){
+			throw new Error("Ticket validity check failed!");
+		}
+
+		await (decodedAttestedObject.getAttestableObject() as EasTicketAttestation).validateEasAttestation()
+
+		return decodedAttestedObject;
 	}
 }

--- a/src/main/javascript/crypto/src/eas/EasZkProof.ts
+++ b/src/main/javascript/crypto/src/eas/EasZkProof.ts
@@ -33,7 +33,7 @@ export class EasZkProof {
 		const idAttest = SignedIdentifierAttestation.fromBytes(base64ToUint8array(base64IdentifierAttestation), KeyPair.publicFromBase64orPEM(attestorPublicKey));
 		const ticketAttest = new EasTicketAttestation(this.schema, undefined, this.rpcMap);
 
-		ticketAttest.loadFromEncoded(base64TicketAttestation, undefined,  <KeysArray>base64senderPublicKeys);
+		ticketAttest.loadFromEncoded(base64TicketAttestation, <KeysArray>base64senderPublicKeys);
 
 		let redeem: AttestedObject = new AttestedObject();
 		redeem.create(ticketAttest, idAttest, identifierSecret, ticketSecret);

--- a/src/main/javascript/crypto/src/main.spec.ts
+++ b/src/main/javascript/crypto/src/main.spec.ts
@@ -890,7 +890,7 @@ describe("EAS Ticket Attestation", () => {
 
         const encoded = attestationManager.getEncoded();
 
-        attestationManager.loadFromEncoded(encoded, undefined, pubKeyConfig);
+        attestationManager.loadFromEncoded(encoded, pubKeyConfig);
         await attestationManager.validateEasAttestation();
     });
 

--- a/src/main/javascript/crypto/src/main.spec.ts
+++ b/src/main/javascript/crypto/src/main.spec.ts
@@ -860,7 +860,7 @@ describe("EAS Ticket Attestation", () => {
 
     async function createAttestation(validity?: {from: number, to: number}){
 
-        await attestationManager.createEasAttestation({
+        return await attestationManager.createEasAttestation({
             devconId: '6',
             ticketIdString: '12345',
             ticketClass: 2,
@@ -940,6 +940,13 @@ describe("EAS Ticket Attestation", () => {
 
         attestationManager.loadEasAttestation(easData.sig, pubKeyConfig);
         await expect(attestationManager.validateEasAttestation()).rejects.toThrowError('Attestation not yet valid.');
+    });
+
+    test("Ensure secrets are difference for each generated attestation", async () => {
+        const attest1 = await createAttestation();
+        const attest2 = await createAttestation();
+
+        expect(attest1.secret).not.toEqual(attest2.secret);
     });
 
     // TODO: Revocation tests with local EVM network

--- a/src/main/javascript/crypto/src/main.spec.ts
+++ b/src/main/javascript/crypto/src/main.spec.ts
@@ -855,7 +855,10 @@ describe("EAS Ticket Attestation", () => {
     const issuerPrivKey = KeyPair.privateFromPEM('MIICSwIBADCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBBIIBVTCCAVECAQEEIM/T+SzcXcdtcNIqo6ck0nJTYzKL5ywYBFNSpI7R8AuBoIHjMIHgAgEBMCwGByqGSM49AQECIQD////////////////////////////////////+///8LzBEBCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcEQQR5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmEg62ncmo8RlXaT7/A4RCKj9F7RIpoVUGZxH0I/7ENS4AiEA/////////////////////rqu3OavSKA7v9JejNA2QUECAQGhRANCAARjMR62qoIK9pHk17MyHHIU42Ix+Vl6Q2gTmIF72vNpinBpyoBkTkV0pnI1jdrLlAjJC0I91DZWQhVhddMCK65c');
     const provider = new ethers.providers.JsonRpcProvider(SEPOLIA_RPC)
     const wallet = new ethers.Wallet(issuerPrivKey.getPrivateAsHexString(), provider)
-    const attestationManager = new EasTicketAttestation(EAS_TICKET_SCHEMA, EAS_CONFIG, wallet);
+    const attestationManager = new EasTicketAttestation(EAS_TICKET_SCHEMA, {
+        EASconfig: EAS_CONFIG,
+        signer: wallet
+    }, {11155111: SEPOLIA_RPC});
     const pubKeyConfig = {"6": issuerPrivKey};
 
     async function createAttestation(validity?: {from: number, to: number}){
@@ -894,13 +897,13 @@ describe("EAS Ticket Attestation", () => {
     test("Load from ASN encoded and validate", async () => {
         await createAttestation();
 
-        const encoded = attestationManager.getAsnEncoded(true, false);
+        const encoded = attestationManager.getAsnEncoded(false);
 
         attestationManager.loadAsnEncoded(encoded, pubKeyConfig, false);
         await attestationManager.validateEasAttestation();
 
 
-        const encodedCompressed = attestationManager.getAsnEncoded(true, true);
+        const encodedCompressed = attestationManager.getAsnEncoded(true);
 
         attestationManager.loadAsnEncoded(encodedCompressed, pubKeyConfig, true);
         await attestationManager.validateEasAttestation();
@@ -958,7 +961,7 @@ describe("EAS Ticket Attestation", () => {
         const ticketBase64 = attestationManager.getEncoded();
         const ticketSecret = attestationManager.getEasJson().secret;
 
-        const easZkProof = new EasZkProof(EAS_TICKET_SCHEMA, EAS_CONFIG, wallet);
+        const easZkProof = new EasZkProof(EAS_TICKET_SCHEMA, {11155111: SEPOLIA_RPC});
 
         // Generate identifier attestation
         const idSecret = (new AttestationCrypto()).makeSecret()
@@ -979,7 +982,7 @@ describe("EAS Ticket Attestation", () => {
         const ticketBase64 = attestationManager.getEncoded();
         const ticketSecret = attestationManager.getEasJson().secret;
 
-        const easZkProof = new EasZkProof(EAS_TICKET_SCHEMA, EAS_CONFIG, wallet);
+        const easZkProof = new EasZkProof(EAS_TICKET_SCHEMA, {11155111: SEPOLIA_RPC});
 
         // Generate identifier attestation
         const idSecret = (new AttestationCrypto()).makeSecret()


### PR DESCRIPTION
- Include domain info in EasTicketAttestation.getDerEncoding. 
  This is required for EIP712 signature validation when UseTicket attestation is used on the blockchain. 
- Make userEthKey param optional in Authenticator.validateUseTicket() to be consistent with EASZKProof.create params. 
- Ensure new commitment secret is generated for each attestation. 
- Fallback to default key when conference ID field is not in use